### PR TITLE
会員登録フォームからAPIにリクエストを送信してユーザー作成する機能を追加

### DIFF
--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -4,6 +4,7 @@ import { Route, Routes } from 'react-router-dom';
 import { ProtectedRoute } from './ProtectedRoute';
 import { SignIn } from '@/components/SignIn/SignIn';
 import { SignUp } from '@/components/SignUp/SignUp';
+import { ConfirmationSent } from '@/components/SignUp/ConfirmationSent';
 
 export const Router = () => {
   return (
@@ -11,6 +12,7 @@ export const Router = () => {
       <Route path="/" element={<Home />} />
       <Route path="/sign_in" element={<SignIn />} />
       <Route path="/sign_up" element={<SignUp />} />
+      <Route path="/sign_up/confirmation_sent" element={<ConfirmationSent />} />
       <Route element={<ProtectedRoute />}>
         <Route path="/student_management" element={<StudentManagement />} />
       </Route>

--- a/src/components/SignIn/SignInForm.tsx
+++ b/src/components/SignIn/SignInForm.tsx
@@ -135,9 +135,9 @@ export function SignInForm({
         </div>
         <Button
           type="submit"
-          className={`w-full ${
-            isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
-          }`}
+          className={cn('w-full', {
+            'opacity-50 cursor-not-allowed': isSubmitting,
+          })}
           disabled={isSubmitting}
         >
           {isSubmitting ? 'ログイン中...' : 'ログイン'}

--- a/src/components/SignIn/SignInForm.tsx
+++ b/src/components/SignIn/SignInForm.tsx
@@ -38,10 +38,10 @@ export function SignInForm({
     setIsSubmitting(true); // 送信中フラグを立てる
 
     try {
-      const response = await api.post<LoginSuccessResponse>(
-        '/api/v1/auth/sign_in',
-        { email, password }
-      );
+      const response = await api.post<LoginSuccessResponse>('/auth/sign_in', {
+        email,
+        password,
+      });
 
       const headers = response.headers;
 

--- a/src/components/SignIn/SignInForm.tsx
+++ b/src/components/SignIn/SignInForm.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@/types/auth';
 import { useAuthStore } from '@/stores/authStore';
 import { useWarningStore } from '@/stores/warningStore';
+import { api } from '@/lib/api';
 
 export function SignInForm({
   className,
@@ -22,20 +23,23 @@ export function SignInForm({
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
   const { setAuth } = useAuthStore();
-  const { VITE_API_BASE_URL } = import.meta.env;
   const warningMessage = useWarningStore((state) => state.warningMessage);
   const setClearWarningMessage = useWarningStore(
     (state) => state.setClearWarningMessage
   );
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault(); // フォームのデフォルト動作を防ぐ
     setError(null); // エラーをリセット
     setClearWarningMessage(); // 警告メッセージをクリア
 
+    if (isSubmitting) return; // すでに送信中の場合は何もしない
+    setIsSubmitting(true); // 送信中フラグを立てる
+
     try {
-      const response = await axios.post<LoginSuccessResponse>(
-        `${VITE_API_BASE_URL}/auth/sign_in`,
+      const response = await api.post<LoginSuccessResponse>(
+        '/api/v1/auth/sign_in',
         { email, password }
       );
 
@@ -59,7 +63,7 @@ export function SignInForm({
         };
 
         setAuth(authHeader);
-        navigate('/student_management');
+        navigate('/student_management', { replace: true });
       } else {
         throw new Error('認証ヘッダーが不足しています');
       }
@@ -78,6 +82,8 @@ export function SignInForm({
       } else {
         setError('予期しないエラーが発生しました。');
       }
+    } finally {
+      setIsSubmitting(false); // 送信中フラグを下ろす
     }
   };
   return (
@@ -127,8 +133,14 @@ export function SignInForm({
             required
           />
         </div>
-        <Button type="submit" className="w-full">
-          ログイン
+        <Button
+          type="submit"
+          className={`w-full ${
+            isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
+          }`}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'ログイン中...' : 'ログイン'}
         </Button>
 
         {/* <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">

--- a/src/components/SignUp/ConfirmationSent.tsx
+++ b/src/components/SignUp/ConfirmationSent.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { CheckCircle2, Mail, ArrowLeft } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export const ConfirmationSent = () => {
+  const navigate = useNavigate();
+  const [countdown, setCountdown] = useState(5); // 5秒後にホームに戻る
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          navigate('/');
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [navigate]);
+
+  const handleBackToHome = () => {
+    navigate('/');
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+            <CheckCircle2 className="h-8 w-8 text-green-600" />
+          </div>
+          <CardTitle className="text-2xl font-bold">
+            確認メールを送信しました
+          </CardTitle>
+          <CardDescription>
+            アカウント作成を完了するため、メールを確認してください
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          <Alert>
+            <Mail className="h-4 w-4" />
+            <AlertTitle>メールを確認してください</AlertTitle>
+            <AlertDescription>
+              メールボックスを確認し、リンクをクリックしてアカウントを有効化してください。
+              メールが見つからない場合は、迷惑メールフォルダもご確認ください。
+            </AlertDescription>
+          </Alert>
+
+          <div className="text-center space-y-4">
+            <p className="text-sm text-muted-foreground">
+              {countdown}秒後に自動でホームページに戻ります
+            </p>
+
+            <Button
+              variant="outline"
+              onClick={handleBackToHome}
+              className="w-full"
+            >
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              ホームに戻る
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/SignUp/ConfirmationSent.tsx
+++ b/src/components/SignUp/ConfirmationSent.tsx
@@ -12,8 +12,9 @@ import {
 } from '@/components/ui/card';
 
 export const ConfirmationSent = () => {
+  const COUNTDOWN_SECONDS: number = 5; // カウントダウンの秒数
   const navigate = useNavigate();
-  const [countdown, setCountdown] = useState(5); // 5秒後にホームに戻る
+  const [countdown, setCountdown] = useState(COUNTDOWN_SECONDS); // 5秒後にホームに戻る
 
   useEffect(() => {
     const timer = setInterval(() => {

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -158,9 +158,9 @@ export function SignUpForm({
 
         <Button
           type="submit"
-          className={`w-full ${
-            isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
-          }`}
+          className={cn('w-full', {
+            'opacity-50 cursor-not-allowed': isSubmitting,
+          })}
           disabled={isSubmitting}
         >
           {isSubmitting ? '登録中...' : '会員登録'}

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -54,7 +54,7 @@ export function SignUpForm({
     setIsSubmitting(true); // 送信中フラグを立てる
 
     try {
-      await api.post<SignUpSuccessResponse>('/api/v1/auth', requestData, {
+      await api.post<SignUpSuccessResponse>('/auth', requestData, {
         headers,
       });
       navigate('/sign_up/confirmation_sent', { replace: true });
@@ -127,11 +127,7 @@ export function SignUpForm({
             className="absolute right-3 top-9"
             onClick={() => setShowPassword((prev) => !prev)}
             tabIndex={-1} // ボタンがフォーカスされないようにする
-            aria-label={
-              showPasswordConfirmation
-                ? 'Hide password confirmation'
-                : 'Show password confirmation'
-            }
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
           >
             {showPassword ? (
               <EyeOff className="h-4 w-4" />

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -30,7 +30,6 @@ export function SignUpForm({
   const confirmSuccessUrl = `${VITE_FRONTEND_URL}/confirmed`;
   // 最初の画面から登録するユーザーは管理者
   const ROLE_ADMIN: string = 'admin';
-  const role: string = ROLE_ADMIN;
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -41,7 +40,7 @@ export function SignUpForm({
       password,
       name,
       password_confirmation: passwordConfirmation,
-      role,
+      role: ROLE_ADMIN,
       confirm_success_url: confirmSuccessUrl,
     };
 
@@ -126,7 +125,6 @@ export function SignUpForm({
             type="button"
             className="absolute right-3 top-9"
             onClick={() => setShowPassword((prev) => !prev)}
-            tabIndex={-1} // ボタンがフォーカスされないようにする
             aria-label={showPassword ? 'Hide password' : 'Show password'}
           >
             {showPassword ? (
@@ -149,7 +147,6 @@ export function SignUpForm({
             type="button"
             className="absolute right-3 top-9"
             onClick={() => setShowPasswordConfirmation((prev) => !prev)}
-            tabIndex={-1} // ボタンがフォーカスされないようにする
             aria-label={
               showPasswordConfirmation
                 ? 'Hide password confirmation'

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -5,13 +5,12 @@ import { Label } from '@/components/ui/label';
 import axios from 'axios';
 import { useState, type FormEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { Eye, EyeOff } from 'lucide-react';
 import type {
-  AuthHeader,
-  LoginErrorResponse,
-  LoginSuccessResponse,
-} from '@/types/auth';
-import { useAuthStore } from '@/stores/authStore';
-import { useWarningStore } from '@/stores/warningStore';
+  SignUpErrorResponse,
+  SignUpSuccessResponse,
+} from '@/types/signUp';
+import { api } from '@/lib/api';
 
 export function SignUpForm({
   className,
@@ -22,61 +21,59 @@ export function SignUpForm({
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState<boolean>(false); // パスワード表示/非表示
+  const [showPasswordConfirmation, setShowPasswordConfirmation] =
+    useState<boolean>(false); // 確認用パスワード表示/非表示
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const navigate = useNavigate();
-  const { setAuth } = useAuthStore();
-  const { VITE_API_BASE_URL } = import.meta.env;
-  const warningMessage = useWarningStore((state) => state.warningMessage);
-  const setClearWarningMessage = useWarningStore(
-    (state) => state.setClearWarningMessage
-  );
+  const { VITE_FRONTEND_URL } = import.meta.env;
+  const confirmSuccessUrl = `${VITE_FRONTEND_URL}/confirmed`;
+  const role: string = 'admin';
 
   const handleSubmit = async (event: FormEvent) => {
-    event.preventDefault(); // フォームのデフォルト動作を防ぐ
-    setError(null); // エラーをリセット
-    setClearWarningMessage(); // 警告メッセージをクリア
+    event.preventDefault();
+    setError(null);
+
+    const requestData = {
+      email,
+      password,
+      name,
+      password_confirmation: passwordConfirmation,
+      role,
+      confirm_success_url: confirmSuccessUrl,
+    };
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+
+    if (isSubmitting) return; // すでに送信中の場合は何もしない
+    setIsSubmitting(true); // 送信中フラグを立てる
 
     try {
-      const response = await axios.post<LoginSuccessResponse>(
-        `${VITE_API_BASE_URL}/auth/sign_up`,
-        { email, password, name, password_confirmation: passwordConfirmation }
-      );
-
-      const headers = response.headers;
-
-      // 必要なプロパティが存在するかチェック
-      if (
-        headers['access-token'] &&
-        headers['client'] &&
-        headers['uid'] &&
-        headers['token-type']
-      ) {
-        // AuthHeader型に必要なプロパティのみを抽出
-        const authHeader: AuthHeader = {
-          'access-token': headers['access-token'],
-          client: headers['client'],
-          uid: headers['uid'],
-          'token-type': headers['token-type'],
-        };
-
-        setAuth(authHeader);
-        navigate('/student_management');
-      } else {
-        throw new Error('認証ヘッダーが不足しています');
-      }
+      await api.post<SignUpSuccessResponse>('/api/v1/auth', requestData, {
+        headers,
+      });
+      navigate('/sign_up/confirmation_sent', { replace: true });
     } catch (err: unknown) {
-      if (axios.isAxiosError<LoginErrorResponse>(err)) {
+      if (axios.isAxiosError<SignUpErrorResponse>(err)) {
         if (err.response) {
-          // レスポンスがある場合、エラーメッセージを設定
-          setError(err.response.data.errors.join(', '));
+          setError(
+            err.response?.data?.errors?.full_messages?.join(', ') ||
+              '新規登録に失敗しました。もう一度お試しください。'
+          );
         } else {
-          // レスポンスがない場合、一般的なエラーメッセージを設定
           setError('新規登録に失敗しました。もう一度お試しください。');
         }
       } else {
         setError('予期しないエラーが発生しました。');
       }
+    } finally {
+      setIsSubmitting(false); // 送信中フラグを下ろす
     }
   };
+
   return (
     <form
       className={cn('flex flex-col gap-6', className)}
@@ -90,9 +87,6 @@ export function SignUpForm({
         </p>
       </div>
       {/* エラーメッセージの表示 */}
-      {warningMessage && (
-        <p className="text-red-500 text-center">{warningMessage}</p>
-      )}
       {error && <p className="text-red-500 text-center">{error}</p>}
 
       <div className="grid gap-6">
@@ -118,28 +112,58 @@ export function SignUpForm({
           />
         </div>
 
-        <div className="grid gap-3">
+        <div className="grid gap-3 relative">
           <Label htmlFor="password">パスワード</Label>
           <Input
             id="password"
-            type="password"
+            type={showPassword ? 'text' : 'password'}
             onChange={(e) => setPassword(e.target.value)}
             required
           />
+          <button
+            type="button"
+            className="absolute right-3 top-9"
+            onClick={() => setShowPassword((prev) => !prev)}
+            tabIndex={-1} // ボタンがフォーカスされないようにする
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </button>
         </div>
 
-        <div className="grid gap-3">
+        <div className="grid gap-3 relative">
           <Label htmlFor="password_confirmation">パスワード確認</Label>
           <Input
             id="password_confirmation"
-            type="password"
+            type={showPasswordConfirmation ? 'text' : 'password'}
             onChange={(e) => setPasswordConfirmation(e.target.value)}
             required
           />
+          <button
+            type="button"
+            className="absolute right-3 top-9"
+            onClick={() => setShowPasswordConfirmation((prev) => !prev)}
+            tabIndex={-1} // ボタンがフォーカスされないようにする
+          >
+            {showPasswordConfirmation ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </button>
         </div>
 
-        <Button type="submit" className="w-full">
-          会員登録
+        <Button
+          type="submit"
+          className={`w-full ${
+            isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
+          }`}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? '登録中...' : '会員登録'}
         </Button>
       </div>
 

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -28,7 +28,9 @@ export function SignUpForm({
   const navigate = useNavigate();
   const { VITE_FRONTEND_URL } = import.meta.env;
   const confirmSuccessUrl = `${VITE_FRONTEND_URL}/confirmed`;
-  const role: string = 'admin';
+  // 最初の画面から登録するユーザーは管理者
+  const ROLE_ADMIN: string = 'admin';
+  const role: string = ROLE_ADMIN;
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -125,6 +127,11 @@ export function SignUpForm({
             className="absolute right-3 top-9"
             onClick={() => setShowPassword((prev) => !prev)}
             tabIndex={-1} // ボタンがフォーカスされないようにする
+            aria-label={
+              showPasswordConfirmation
+                ? 'Hide password confirmation'
+                : 'Show password confirmation'
+            }
           >
             {showPassword ? (
               <EyeOff className="h-4 w-4" />
@@ -147,6 +154,11 @@ export function SignUpForm({
             className="absolute right-3 top-9"
             onClick={() => setShowPasswordConfirmation((prev) => !prev)}
             tabIndex={-1} // ボタンがフォーカスされないようにする
+            aria-label={
+              showPasswordConfirmation
+                ? 'Hide password confirmation'
+                : 'Show password confirmation'
+            }
           >
             {showPasswordConfirmation ? (
               <EyeOff className="h-4 w-4" />

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,7 +3,7 @@ import axios, { type InternalAxiosRequestConfig } from 'axios';
 
 export const api = axios.create({
   // APIのベースURLを環境変数から取得
-  baseURL: `${import.meta.env.VITE_API_BASE_URL}/api/v1`,
+  baseURL: `${import.meta.env.VITE_API_BASE_URL}`,
 });
 
 // ヘッダー名の定数を定義
@@ -11,6 +11,7 @@ const HEADER_ACCESS_TOKEN = 'access-token';
 const HEADER_CLIENT = 'client';
 const HEADER_UID = 'uid';
 const HEADER_TOKEN_TYPE = 'token-type';
+const HEADER_EXPIRY = 'expiry';
 
 // リクエスト前に自動でヘッダーを付与
 api.interceptors.request.use(
@@ -23,6 +24,7 @@ api.interceptors.request.use(
       config.headers[HEADER_CLIENT] = auth.client;
       config.headers[HEADER_UID] = auth.uid;
       config.headers[HEADER_TOKEN_TYPE] = auth['token-type'];
+      config.headers[HEADER_EXPIRY] = auth.expiry;
     }
     return config;
   },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,7 +3,7 @@ import axios, { type InternalAxiosRequestConfig } from 'axios';
 
 export const api = axios.create({
   // APIのベースURLを環境変数から取得
-  baseURL: `${import.meta.env.VITE_API_BASE_URL}`,
+  baseURL: `${import.meta.env.VITE_API_BASE_URL}/api/v1`,
 });
 
 // ヘッダー名の定数を定義

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -9,7 +9,7 @@ const VITE_API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export const handlers = [
   http.post<LoginPathParams, LoginRequestBodyType, LoginResponseBodyType>(
-    `${VITE_API_BASE_URL}/auth/sign_in`,
+    `${VITE_API_BASE_URL}/api/v1/auth/sign_in`,
     async ({ request }) => {
       // リクエストボディからemailとpasswordを取得
       const body = await request.json();

--- a/src/types/signUp.ts
+++ b/src/types/signUp.ts
@@ -1,0 +1,38 @@
+export type SignUpSuccessResponse = {
+  data: {
+    id: number;
+    provider: string;
+    uid: string;
+    allow_password_change: boolean;
+    name: string;
+    role: string;
+    school_stage: string | null;
+    grade: number | null;
+    graduated_university: string | null;
+    email: string;
+    created_at: string;
+    updated_at: string;
+  };
+};
+
+// 失敗の場合の型定義
+export type SignUpErrorResponse = {
+  data: {
+    id: number | null;
+    provider: string;
+    uid: string;
+    allow_password_change: boolean;
+    name: string;
+    role: string;
+    school_stage?: number | null;
+    grade?: number | null;
+    graduated_university?: string | null;
+    email: string;
+    created_at: string | null;
+    updated_at: string | null;
+  };
+  errors: {
+    [key: string]: string[]; // email, password_confirmation などのフィールドごとのエラー
+    full_messages: string[]; // ユーザー向けにまとめたメッセージ
+  };
+};

--- a/src/types/signUp.ts
+++ b/src/types/signUp.ts
@@ -24,7 +24,7 @@ export type SignUpErrorResponse = {
     allow_password_change: boolean;
     name: string;
     role: string;
-    school_stage?: number | null;
+    school_stage?: string | null;
     grade?: number | null;
     graduated_university?: string | null;
     email: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,9 @@ import tailwindcss from '@tailwindcss/vite';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    'process.env': {},
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## ISSUE

close #15 

## 実装概要

- 会員登録フォームからAPIにリクエストを送信してユーザー作成する機能を追加しました。
- パスワードと確認用パスワードに目のアイコンを追加し、表示/非表示を切り替えられるようにしました。
- 会員登録成功後に確認メール送信画面（`ConfirmationSent`）へリダイレクトする機能を実装しました。
- `ConfirmationSent`コンポーネントでカウントダウン後にホームページへ自動リダイレクトする機能を追加しました。
- APIリクエストのベースURLを環境変数から取得するように修正しました。
- `SignUp` の成功・失敗レスポンスの型定義を追加しました。

## スクリーンショット

<!-- 変更前後のスクリーンショットやGIFを貼ってください。なければ省略可能です -->

## 動作確認手順

<!-- レビュアーが確認しやすいように、操作手順を具体的に記載してください -->

1. `/sign_up` にアクセスし、会員登録フォームが正しく表示されることを確認。
2. 必須項目を入力し、登録ボタンをクリックすると、確認メール送信画面にリダイレクトされることを確認。
3. 確認メール送信画面でカウントダウン後にホームページへ自動リダイレクトされることを確認。
4. パスワードと確認用パスワードの目のアイコンをクリックすると、入力内容が表示/非表示に切り替わることを確認。
5. APIリクエストが正しく送信され、レスポンスが期待通りであることを確認。

## 影響範囲

- 会員登録画面（`SignUpForm`）
- 確認メール送信画面（`ConfirmationSent`）
- APIリクエストの設定（`api.ts`）
- 型定義（`signUp.ts`）
- ルーティング（`Router.tsx`）

## レビューポイント

<!-- レビュアーに特に見てほしい点があればチェックを入れてください -->

- [x] **機能**：仕様どおりに動作するか
- [x] **コード品質**：可読性・保守性
- [x] **セキュリティ**：権限・バリデーション・入力チェック
- [x] **パフォーマンス**：処理速度やリソース使用量
- [x] **CI**：GitHub Actions のワークフローが成功しているか

## デプロイ／運用

<!-- 該当する項目にチェックを入れて、必要に応じて補足してください -->

- **マイグレーション**：無
- **環境変数の追加**：有（`.env.developmen`t に `VITE_FRONTEND_URL` と `VITE_API_BASE_URL`を追加）
- **破壊的変更の有無**：無
## チェックリスト（作成者用）

<!-- PR作成前に確認した内容にチェックを入れてください -->

- [x] 自身で動作確認・コードレビューを完了した
- [x] 不要なコメント・デバッグコードを削除した
- [x] コミットメッセージがわかりやすく記述されている
- [x] 関連 Issue がリンクされている（あれば）

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか
