### PR TITLE
ログイン後に戻るボタンで戻れてしまうバクの修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
+import { useEffect } from 'react';
 import './App.css';
 import { Router } from './Router/Router';
 import { useAuthStore } from './stores/authStore';
 
 function App() {
-  // 開発環境では、認証ストアの永続化をクリアする
-  if (process.env.NODE_ENV === 'development') {
-    useAuthStore.persist.clearStorage();
-  }
+  useEffect(() => {
+    // 開発環境では、認証ストアの永続化をクリアする
+    if (process.env.NODE_ENV === 'development') {
+      useAuthStore.persist.clearStorage();
+    }
+  }, []);
   return (
     <>
       <Router />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,12 @@
 import './App.css';
 import { Router } from './Router/Router';
+import { useAuthStore } from './stores/authStore';
 
 function App() {
+  // 開発環境では、認証ストアの永続化をクリアする
+  if (process.env.NODE_ENV === 'development') {
+    useAuthStore.persist.clearStorage();
+  }
   return (
     <>
       <Router />

--- a/src/Router/AuthRoute.tsx
+++ b/src/Router/AuthRoute.tsx
@@ -5,12 +5,13 @@ import { Outlet, useNavigate } from 'react-router-dom';
 export const AuthRoute = () => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const navigate = useNavigate();
+  const isUserAuthenticated = isAuthenticated();
 
   useEffect(() => {
-    if (isAuthenticated()) {
+    if (isUserAuthenticated) {
       navigate('/student_management', { replace: true });
     }
-  }, [isAuthenticated, navigate]);
+  }, [isUserAuthenticated, navigate]);
 
-  return isAuthenticated() ? null : <Outlet />;
+  return isUserAuthenticated ? null : <Outlet />;
 };

--- a/src/Router/AuthRoute.tsx
+++ b/src/Router/AuthRoute.tsx
@@ -1,0 +1,16 @@
+import { useAuthStore } from '@/stores/authStore';
+import { useEffect } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+
+export const AuthRoute = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isAuthenticated()) {
+      navigate('/student_management', { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
+
+  return isAuthenticated() ? null : <Outlet />;
+};

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -7,15 +7,22 @@ import { SignUp } from '@/components/SignUp/SignUp';
 import { ConfirmationSent } from '@/components/Confirm/ConfirmationSent';
 import { ConfirmedPage } from '@/components/Confirm/ConfirmedPage';
 import { NotFound } from '@/components/Error/NotFound';
+import { AuthRoute } from './AuthRoute';
 
 export const Router = () => {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/sign_up" element={<SignUp />} />
-      <Route path="/sign_up/confirmation_sent" element={<ConfirmationSent />} />
-      <Route path="/confirmed" element={<ConfirmedPage />} />
-      <Route path="/sign_in" element={<SignIn />} />
+      {/** ログイン前のページ */}
+      <Route element={<AuthRoute />}>
+        <Route path="/" element={<Home />} />
+        <Route path="/sign_up" element={<SignUp />} />
+        <Route
+          path="/sign_up/confirmation_sent"
+          element={<ConfirmationSent />}
+        />
+        <Route path="/confirmed" element={<ConfirmedPage />} />
+        <Route path="/sign_in" element={<SignIn />} />
+      </Route>
       {/** ログイン後のページ */}
       <Route element={<ProtectedRoute />}>
         <Route path="/student_management" element={<StudentManagement />} />

--- a/src/components/SignIn/SignInForm.tsx
+++ b/src/components/SignIn/SignInForm.tsx
@@ -63,6 +63,7 @@ export function SignInForm({
         };
 
         setAuth(authHeader);
+        window.history.replaceState(null, '', '/student_management');
         navigate('/student_management', { replace: true });
       } else {
         throw new Error('認証ヘッダーが不足しています');

--- a/src/components/SignIn/SignInForm.tsx
+++ b/src/components/SignIn/SignInForm.tsx
@@ -63,7 +63,6 @@ export function SignInForm({
         };
 
         setAuth(authHeader);
-        window.history.replaceState(null, '', '/student_management');
         navigate('/student_management', { replace: true });
       } else {
         throw new Error('認証ヘッダーが不足しています');

--- a/src/tests/components/SignIn/SignInform.test.tsx
+++ b/src/tests/components/SignIn/SignInform.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { useAuthStore } from '@/stores/authStore';
 import { SignIn } from '@/components/SignIn/SignIn';
+import { act } from 'react';
 
 // テスト用のコンポーネント
 const StudentManagement = () => (
@@ -65,6 +66,14 @@ describe('SignIn form integration tests', () => {
     });
 
     // ページ遷移の確認
+    await waitFor(() => {
+      expect(screen.getByTestId('student-management')).toBeInTheDocument();
+    });
+
+    act(() => {
+      window.history.back();
+    });
+    // 戻るボタンを押してもstudent-management にとどまることを確認
     await waitFor(() => {
       expect(screen.getByTestId('student-management')).toBeInTheDocument();
     });

--- a/src/tests/components/SignIn/SignInform.test.tsx
+++ b/src/tests/components/SignIn/SignInform.test.tsx
@@ -4,7 +4,6 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { useAuthStore } from '@/stores/authStore';
 import { SignIn } from '@/components/SignIn/SignIn';
-import { act } from 'react';
 
 // テスト用のコンポーネント
 const StudentManagement = () => (
@@ -70,9 +69,8 @@ describe('SignIn form integration tests', () => {
       expect(screen.getByTestId('student-management')).toBeInTheDocument();
     });
 
-    act(() => {
-      window.history.back();
-    });
+    window.history.back();
+
     // 戻るボタンを押してもstudent-management にとどまることを確認
     await waitFor(() => {
       expect(screen.getByTestId('student-management')).toBeInTheDocument();


### PR DESCRIPTION
## ISSUE

close #25 

## 実装概要

<!-- この PR の目的・背景を 1～2 行で記載してください（例：バグ修正、UI改善、パフォーマンス向上など） -->
ログイン後にブラウザの戻るボタンで認証前のページに戻れてしまうセキュリティ問題を修正。
認証済みユーザーが認証ページにアクセスしようとした場合、自動的に保護されたページにリダイレクトする機能を実装。

## スクリーンショット

<!-- 変更前後のスクリーンショットやGIFを貼ってください。なければ省略可能です -->

## 動作確認手順

<!-- レビュアーが確認しやすいように、操作手順を具体的に記載してください -->
1. 開発サーバーを起動 `npm run dev`
2. `/sign_in` にアクセスしてログインを実行
3. ログイン成功後、`/student_management` に自動遷移することを確認
4. ブラウザの戻るボタンを押す
5. `/sign_in` ページに戻らず、`/student_management` にとどまることを確認
6. 手動で `/sign_in` のURLにアクセスしても `/student_management` にリダイレクトされることを確認
ログアウト後、認証ページに正常にアクセスできることを確認

## 影響範囲

### 新規作成
- `src/Router/AuthRoute.tsx`（認証済みユーザー用のルートガード）
### 修正
- `src/Router/Router.tsx`（AuthRouteの適用）
- `src/components/SignIn/SignInForm.tsx`（ヒストリー操作の追加）
- `src/App.tsx`（開発環境での認証ストアクリア）
- `src/tests/components/SignIn/SignInform.test.tsx`（戻るボタンのテスト追加）

## レビューポイント

<!-- レビュアーに特に見てほしい点があればチェックを入れてください -->

- [x] **機能**：仕様どおりに動作するか
- [x] **コード品質**：可読性・保守性
- [x] **セキュリティ**：権限・バリデーション・入力チェック
- [ ] **パフォーマンス**：処理速度やリソース使用量
- [ ] **CI**：GitHub Actions のワークフローが成功しているか

## デプロイ／運用

<!-- 該当する項目にチェックを入れて、必要に応じて補足してください -->

- **マイグレーション**：有／無（テーブル追加、カラム変更など）
- **環境変数の追加**：有／無（.env や GitHub Secrets 等）
- **破壊的変更の有無**：有／無（既存データへの影響など）

## チェックリスト（作成者用）

<!-- PR作成前に確認した内容にチェックを入れてください -->

- [ ] 自身で動作確認・コードレビューを完了した
- [ ] 不要なコメント・デバッグコードを削除した
- [ ] コミットメッセージがわかりやすく記述されている
- [ ] 関連 Issue がリンクされている（あれば）

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか
