### PR TITLE
TeachersPage のUI及びダミーデータの作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-scroll-area": "^1.2.9",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
@@ -1783,6 +1784,37 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.9.tgz",
+      "integrity": "sha512-YSjEfBXnhUELsO2VzjdtYYD4CfQjvao+lhhrX5XsHD7/cyUNzljF1FHEbgTPN7LH2MClfwRMIsYlqTYpKTTe2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",

--- a/src/components/common/dashboard/data-table.tsx
+++ b/src/components/common/dashboard/data-table.tsx
@@ -1,0 +1,818 @@
+import * as React from 'react';
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type UniqueIdentifier,
+} from '@dnd-kit/core';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
+  IconChevronDown,
+  IconChevronLeft,
+  IconChevronRight,
+  IconChevronsLeft,
+  IconChevronsRight,
+  IconCircleCheckFilled,
+  IconDotsVertical,
+  IconGripVertical,
+  IconLayoutColumns,
+  IconLoader,
+  IconPlus,
+  IconTrendingUp,
+} from '@tabler/icons-react';
+import {
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import type {
+  ColumnDef,
+  ColumnFiltersState,
+  Row,
+  SortingState,
+  VisibilityState,
+} from '@tanstack/react-table';
+import { Area, AreaChart, CartesianGrid, XAxis } from 'recharts';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { useIsMobile } from '@/hooks/useMobile';
+import { Badge } from '@/components/ui/display/Badge/badge';
+import { Button } from '@/components/ui/form/Button/button';
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/display/Chart/chart';
+import type { ChartConfig } from '@/components/ui/display/Chart/chart';
+import { Checkbox } from '@/components/ui/form/CheckBox/checkbox';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/layout/Drawer/drawer';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/navigation/DropdownMenu/dropdown-menu';
+import { Input } from '@/components/ui/form/Input/input';
+import { Label } from '@/components/ui/form/Label/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/form/Select/select';
+import { Separator } from '@/components/ui/layout/Separator/separator';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/display/Table/table';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/navigation/Tabs/tabs';
+
+export const schema = z.object({
+  id: z.number(),
+  header: z.string(),
+  type: z.string(),
+  status: z.string(),
+  target: z.string(),
+  limit: z.string(),
+  reviewer: z.string(),
+});
+
+// Create a separate component for the drag handle
+function DragHandle({ id }: { id: number }) {
+  const { attributes, listeners } = useSortable({
+    id,
+  });
+
+  return (
+    <Button
+      {...attributes}
+      {...listeners}
+      variant="ghost"
+      size="icon"
+      className="text-muted-foreground size-7 hover:bg-transparent"
+    >
+      <IconGripVertical className="text-muted-foreground size-3" />
+      <span className="sr-only">Drag to reorder</span>
+    </Button>
+  );
+}
+
+{
+  /** 表のカラムの定義 */
+}
+const columns: ColumnDef<z.infer<typeof schema>>[] = [
+  {
+    id: 'drag',
+    header: () => null,
+    cell: ({ row }) => <DragHandle id={row.original.id} />,
+  },
+  {
+    id: 'select',
+    header: ({ table }) => (
+      <div className="flex items-center justify-center">
+        <Checkbox
+          checked={
+            table.getIsAllPageRowsSelected() ||
+            (table.getIsSomePageRowsSelected() && 'indeterminate')
+          }
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+          aria-label="Select all"
+        />
+      </div>
+    ),
+    cell: ({ row }) => (
+      <div className="flex items-center justify-center">
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(value) => row.toggleSelected(!!value)}
+          aria-label="Select row"
+        />
+      </div>
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: 'header',
+    header: 'Header',
+    cell: ({ row }) => {
+      return <TableCellViewer item={row.original} />;
+    },
+    enableHiding: false,
+  },
+  {
+    accessorKey: 'type',
+    header: 'Section Type',
+    cell: ({ row }) => (
+      <div className="w-32">
+        <Badge variant="outline" className="text-muted-foreground px-1.5">
+          {row.original.type}
+        </Badge>
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => (
+      <Badge variant="outline" className="text-muted-foreground px-1.5">
+        {row.original.status === 'Done' ? (
+          <IconCircleCheckFilled className="fill-green-500 dark:fill-green-400" />
+        ) : (
+          <IconLoader />
+        )}
+        {row.original.status}
+      </Badge>
+    ),
+  },
+  {
+    accessorKey: 'target',
+    header: () => <div className="w-full text-right">Target</div>,
+    cell: ({ row }) => (
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          toast.promise(new Promise((resolve) => setTimeout(resolve, 1000)), {
+            loading: `Saving ${row.original.header}`,
+            success: 'Done',
+            error: 'Error',
+          });
+        }}
+      >
+        <Label htmlFor={`${row.original.id}-target`} className="sr-only">
+          Target
+        </Label>
+        <Input
+          className="hover:bg-input/30 focus-visible:bg-background dark:hover:bg-input/30 dark:focus-visible:bg-input/30 h-8 w-16 border-transparent bg-transparent text-right shadow-none focus-visible:border dark:bg-transparent"
+          defaultValue={row.original.target}
+          id={`${row.original.id}-target`}
+        />
+      </form>
+    ),
+  },
+  {
+    accessorKey: 'limit',
+    header: () => <div className="w-full text-right">Limit</div>,
+    cell: ({ row }) => (
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          toast.promise(new Promise((resolve) => setTimeout(resolve, 1000)), {
+            loading: `Saving ${row.original.header}`,
+            success: 'Done',
+            error: 'Error',
+          });
+        }}
+      >
+        <Label htmlFor={`${row.original.id}-limit`} className="sr-only">
+          Limit
+        </Label>
+        <Input
+          className="hover:bg-input/30 focus-visible:bg-background dark:hover:bg-input/30 dark:focus-visible:bg-input/30 h-8 w-16 border-transparent bg-transparent text-right shadow-none focus-visible:border dark:bg-transparent"
+          defaultValue={row.original.limit}
+          id={`${row.original.id}-limit`}
+        />
+      </form>
+    ),
+  },
+  {
+    accessorKey: 'reviewer',
+    header: 'Reviewer',
+    cell: ({ row }) => {
+      const isAssigned = row.original.reviewer !== 'Assign reviewer';
+
+      if (isAssigned) {
+        return row.original.reviewer;
+      }
+
+      return (
+        <>
+          <Label htmlFor={`${row.original.id}-reviewer`} className="sr-only">
+            Reviewer
+          </Label>
+          <Select>
+            <SelectTrigger
+              className="w-38 **:data-[slot=select-value]:block **:data-[slot=select-value]:truncate"
+              size="sm"
+              id={`${row.original.id}-reviewer`}
+            >
+              <SelectValue placeholder="Assign reviewer" />
+            </SelectTrigger>
+            <SelectContent align="end">
+              <SelectItem value="Eddie Lake">Eddie Lake</SelectItem>
+              <SelectItem value="Jamik Tashpulatov">
+                Jamik Tashpulatov
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </>
+      );
+    },
+  },
+  {
+    id: 'actions',
+    cell: () => (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            className="data-[state=open]:bg-muted text-muted-foreground flex size-8"
+            size="icon"
+          >
+            <IconDotsVertical />
+            <span className="sr-only">Open menu</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-32">
+          <DropdownMenuItem>Edit</DropdownMenuItem>
+          <DropdownMenuItem>Make a copy</DropdownMenuItem>
+          <DropdownMenuItem>Favorite</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    ),
+  },
+];
+
+function DraggableRow({ row }: { row: Row<z.infer<typeof schema>> }) {
+  const { transform, transition, setNodeRef, isDragging } = useSortable({
+    id: row.original.id,
+  });
+
+  return (
+    <TableRow
+      data-state={row.getIsSelected() && 'selected'}
+      data-dragging={isDragging}
+      ref={setNodeRef}
+      className="relative z-0 data-[dragging=true]:z-10 data-[dragging=true]:opacity-80"
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition: transition,
+      }}
+    >
+      {row.getVisibleCells().map((cell) => (
+        <TableCell key={cell.id}>
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </TableCell>
+      ))}
+    </TableRow>
+  );
+}
+
+export function DataTable({
+  data: initialData,
+}: {
+  data: z.infer<typeof schema>[];
+}) {
+  const [data, setData] = React.useState(() => initialData);
+  const [rowSelection, setRowSelection] = React.useState({});
+  const [columnVisibility, setColumnVisibility] =
+    React.useState<VisibilityState>({});
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    []
+  );
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [pagination, setPagination] = React.useState({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+  const sortableId = React.useId();
+  const sensors = useSensors(
+    useSensor(MouseSensor, {}),
+    useSensor(TouchSensor, {}),
+    useSensor(KeyboardSensor, {})
+  );
+
+  const dataIds = React.useMemo<UniqueIdentifier[]>(
+    () => data?.map(({ id }) => id) || [],
+    [data]
+  );
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      columnVisibility,
+      rowSelection,
+      columnFilters,
+      pagination,
+    },
+    getRowId: (row) => row.id.toString(),
+    enableRowSelection: true,
+    onRowSelectionChange: setRowSelection,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange: setColumnVisibility,
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+  });
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (active && over && active.id !== over.id) {
+      setData((data) => {
+        const oldIndex = dataIds.indexOf(active.id);
+        const newIndex = dataIds.indexOf(over.id);
+        return arrayMove(data, oldIndex, newIndex);
+      });
+    }
+  }
+
+  return (
+    <Tabs
+      defaultValue="outline"
+      className="w-full flex-col justify-start gap-6"
+    >
+      <div className="flex items-center justify-between px-4 lg:px-6">
+        <Label htmlFor="view-selector" className="sr-only">
+          View
+        </Label>
+        {/** セレクター or タブ */}
+        <Select defaultValue="outline">
+          <SelectTrigger
+            className="flex w-fit @4xl/main:hidden"
+            size="sm"
+            id="view-selector"
+          >
+            <SelectValue placeholder="Select a view" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="outline">Outline</SelectItem>
+            <SelectItem value="past-performance">Past Performance</SelectItem>
+            <SelectItem value="key-personnel">Key Personnel</SelectItem>
+            <SelectItem value="focus-documents">Focus Documents</SelectItem>
+          </SelectContent>
+        </Select>
+        <TabsList className="**:data-[slot=badge]:bg-muted-foreground/30 hidden **:data-[slot=badge]:size-5 **:data-[slot=badge]:rounded-full **:data-[slot=badge]:px-1 @4xl/main:flex">
+          <TabsTrigger value="outline">Outline</TabsTrigger>
+          <TabsTrigger value="past-performance">
+            Past Performance <Badge variant="secondary">3</Badge>
+          </TabsTrigger>
+          <TabsTrigger value="key-personnel">
+            Key Personnel <Badge variant="secondary">2</Badge>
+          </TabsTrigger>
+          <TabsTrigger value="focus-documents">Focus Documents</TabsTrigger>
+        </TabsList>
+
+        {/** カラムのカスタマイズとセクション追加ボタン */}
+        <div className="flex items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm">
+                <IconLayoutColumns />
+                <span className="hidden lg:inline">Customize Columns</span>
+                <span className="lg:hidden">Columns</span>
+                <IconChevronDown />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              {table
+                .getAllColumns()
+                .filter(
+                  (column) =>
+                    typeof column.accessorFn !== 'undefined' &&
+                    column.getCanHide()
+                )
+                .map((column) => {
+                  return (
+                    <DropdownMenuCheckboxItem
+                      key={column.id}
+                      className="capitalize"
+                      checked={column.getIsVisible()}
+                      onCheckedChange={(value) =>
+                        column.toggleVisibility(!!value)
+                      }
+                    >
+                      {column.id}
+                    </DropdownMenuCheckboxItem>
+                  );
+                })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button variant="outline" size="sm">
+            <IconPlus />
+            <span className="hidden lg:inline">Add Section</span>
+          </Button>
+        </div>
+        {/** Outline タブの内容 */}
+      </div>
+      <TabsContent
+        value="outline"
+        className="relative flex flex-col gap-4 overflow-auto px-4 lg:px-6"
+      >
+        <div className="overflow-hidden rounded-lg border">
+          <DndContext
+            collisionDetection={closestCenter}
+            modifiers={[restrictToVerticalAxis]}
+            onDragEnd={handleDragEnd}
+            sensors={sensors}
+            id={sortableId}
+          >
+            <Table>
+              <TableHeader className="bg-muted sticky top-0 z-10">
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => {
+                      return (
+                        <TableHead key={header.id} colSpan={header.colSpan}>
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                              )}
+                        </TableHead>
+                      );
+                    })}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody className="**:data-[slot=table-cell]:first:w-8">
+                {table.getRowModel().rows?.length ? (
+                  <SortableContext
+                    items={dataIds}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    {table.getRowModel().rows.map((row) => (
+                      <DraggableRow key={row.id} row={row} />
+                    ))}
+                  </SortableContext>
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={columns.length}
+                      className="h-24 text-center"
+                    >
+                      No results.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </DndContext>
+        </div>
+        {/** ページネーションと選択状態の表示 */}
+        <div className="flex items-center justify-between px-4">
+          <div className="text-muted-foreground hidden flex-1 text-sm lg:flex">
+            {table.getFilteredSelectedRowModel().rows.length} of{' '}
+            {table.getFilteredRowModel().rows.length} row(s) selected.
+          </div>
+          <div className="flex w-full items-center gap-8 lg:w-fit">
+            <div className="hidden items-center gap-2 lg:flex">
+              <Label htmlFor="rows-per-page" className="text-sm font-medium">
+                Rows per page
+              </Label>
+              <Select
+                value={`${table.getState().pagination.pageSize}`}
+                onValueChange={(value) => {
+                  table.setPageSize(Number(value));
+                }}
+              >
+                <SelectTrigger size="sm" className="w-20" id="rows-per-page">
+                  <SelectValue
+                    placeholder={table.getState().pagination.pageSize}
+                  />
+                </SelectTrigger>
+                <SelectContent side="top">
+                  {[10, 20, 30, 40, 50].map((pageSize) => (
+                    <SelectItem key={pageSize} value={`${pageSize}`}>
+                      {pageSize}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex w-fit items-center justify-center text-sm font-medium">
+              Page {table.getState().pagination.pageIndex + 1} of{' '}
+              {table.getPageCount()}
+            </div>
+            <div className="ml-auto flex items-center gap-2 lg:ml-0">
+              <Button
+                variant="outline"
+                className="hidden h-8 w-8 p-0 lg:flex"
+                onClick={() => table.setPageIndex(0)}
+                disabled={!table.getCanPreviousPage()}
+              >
+                <span className="sr-only">Go to first page</span>
+                <IconChevronsLeft />
+              </Button>
+              <Button
+                variant="outline"
+                className="size-8"
+                size="icon"
+                onClick={() => table.previousPage()}
+                disabled={!table.getCanPreviousPage()}
+              >
+                <span className="sr-only">Go to previous page</span>
+                <IconChevronLeft />
+              </Button>
+              <Button
+                variant="outline"
+                className="size-8"
+                size="icon"
+                onClick={() => table.nextPage()}
+                disabled={!table.getCanNextPage()}
+              >
+                <span className="sr-only">Go to next page</span>
+                <IconChevronRight />
+              </Button>
+              <Button
+                variant="outline"
+                className="hidden size-8 lg:flex"
+                size="icon"
+                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+                disabled={!table.getCanNextPage()}
+              >
+                <span className="sr-only">Go to last page</span>
+                <IconChevronsRight />
+              </Button>
+            </div>
+          </div>
+        </div>
+      </TabsContent>
+      <TabsContent
+        value="past-performance"
+        className="flex flex-col px-4 lg:px-6"
+      >
+        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
+      </TabsContent>
+      <TabsContent value="key-personnel" className="flex flex-col px-4 lg:px-6">
+        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
+      </TabsContent>
+      <TabsContent
+        value="focus-documents"
+        className="flex flex-col px-4 lg:px-6"
+      >
+        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+const chartData = [
+  { month: 'January', desktop: 186, mobile: 80 },
+  { month: 'February', desktop: 305, mobile: 200 },
+  { month: 'March', desktop: 237, mobile: 120 },
+  { month: 'April', desktop: 73, mobile: 190 },
+  { month: 'May', desktop: 209, mobile: 130 },
+  { month: 'June', desktop: 214, mobile: 140 },
+];
+
+const chartConfig = {
+  desktop: {
+    label: 'Desktop',
+    color: 'var(--primary)',
+  },
+  mobile: {
+    label: 'Mobile',
+    color: 'var(--primary)',
+  },
+} satisfies ChartConfig;
+
+{
+  /** ドロワー内で表示されるテーブルセルのコンテンツ */
+}
+function TableCellViewer({ item }: { item: z.infer<typeof schema> }) {
+  const isMobile = useIsMobile();
+
+  return (
+    <Drawer direction={isMobile ? 'bottom' : 'right'}>
+      <DrawerTrigger asChild>
+        <Button variant="link" className="text-foreground w-fit px-0 text-left">
+          {item.header}
+        </Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader className="gap-1">
+          <DrawerTitle>{item.header}</DrawerTitle>
+          <DrawerDescription>
+            Showing total visitors for the last 6 months
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="flex flex-col gap-4 overflow-y-auto px-4 text-sm">
+          {!isMobile && (
+            <>
+              <ChartContainer config={chartConfig}>
+                <AreaChart
+                  accessibilityLayer
+                  data={chartData}
+                  margin={{
+                    left: 0,
+                    right: 10,
+                  }}
+                >
+                  <CartesianGrid vertical={false} />
+                  <XAxis
+                    dataKey="month"
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={8}
+                    tickFormatter={(value) => value.slice(0, 3)}
+                    hide
+                  />
+                  <ChartTooltip
+                    cursor={false}
+                    content={<ChartTooltipContent indicator="dot" />}
+                  />
+                  <Area
+                    dataKey="mobile"
+                    type="natural"
+                    fill="var(--color-mobile)"
+                    fillOpacity={0.6}
+                    stroke="var(--color-mobile)"
+                    stackId="a"
+                  />
+                  <Area
+                    dataKey="desktop"
+                    type="natural"
+                    fill="var(--color-desktop)"
+                    fillOpacity={0.4}
+                    stroke="var(--color-desktop)"
+                    stackId="a"
+                  />
+                </AreaChart>
+              </ChartContainer>
+              <Separator />
+              <div className="grid gap-2">
+                <div className="flex gap-2 leading-none font-medium">
+                  Trending up by 5.2% this month{' '}
+                  <IconTrendingUp className="size-4" />
+                </div>
+                <div className="text-muted-foreground">
+                  Showing total visitors for the last 6 months. This is just
+                  some random text to test the layout. It spans multiple lines
+                  and should wrap around.
+                </div>
+              </div>
+              <Separator />
+            </>
+          )}
+          <form className="flex flex-col gap-4">
+            <div className="flex flex-col gap-3">
+              <Label htmlFor="header">Header</Label>
+              <Input id="header" defaultValue={item.header} />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex flex-col gap-3">
+                <Label htmlFor="type">Type</Label>
+                <Select defaultValue={item.type}>
+                  <SelectTrigger id="type" className="w-full">
+                    <SelectValue placeholder="Select a type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Table of Contents">
+                      Table of Contents
+                    </SelectItem>
+                    <SelectItem value="Executive Summary">
+                      Executive Summary
+                    </SelectItem>
+                    <SelectItem value="Technical Approach">
+                      Technical Approach
+                    </SelectItem>
+                    <SelectItem value="Design">Design</SelectItem>
+                    <SelectItem value="Capabilities">Capabilities</SelectItem>
+                    <SelectItem value="Focus Documents">
+                      Focus Documents
+                    </SelectItem>
+                    <SelectItem value="Narrative">Narrative</SelectItem>
+                    <SelectItem value="Cover Page">Cover Page</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex flex-col gap-3">
+                <Label htmlFor="status">Status</Label>
+                <Select defaultValue={item.status}>
+                  <SelectTrigger id="status" className="w-full">
+                    <SelectValue placeholder="Select a status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Done">Done</SelectItem>
+                    <SelectItem value="In Progress">In Progress</SelectItem>
+                    <SelectItem value="Not Started">Not Started</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex flex-col gap-3">
+                <Label htmlFor="target">Target</Label>
+                <Input id="target" defaultValue={item.target} />
+              </div>
+              <div className="flex flex-col gap-3">
+                <Label htmlFor="limit">Limit</Label>
+                <Input id="limit" defaultValue={item.limit} />
+              </div>
+            </div>
+            <div className="flex flex-col gap-3">
+              <Label htmlFor="reviewer">Reviewer</Label>
+              <Select defaultValue={item.reviewer}>
+                <SelectTrigger id="reviewer" className="w-full">
+                  <SelectValue placeholder="Select a reviewer" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Eddie Lake">Eddie Lake</SelectItem>
+                  <SelectItem value="Jamik Tashpulatov">
+                    Jamik Tashpulatov
+                  </SelectItem>
+                  <SelectItem value="Emily Whalen">Emily Whalen</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </form>
+        </div>
+        <DrawerFooter>
+          <Button>Submit</Button>
+          <DrawerClose asChild>
+            <Button variant="outline">Done</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/components/ui/layout/ScrollArea/scroll-area.tsx
+++ b/src/components/ui/layout/ScrollArea/scroll-area.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/src/components/ui/layout/ScrollArea/scroll-area.tsx
+++ b/src/components/ui/layout/ScrollArea/scroll-area.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+import * as React from 'react';
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function ScrollArea({
   className,
@@ -11,7 +11,7 @@ function ScrollArea({
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn("relative", className)}
+      className={cn('relative', className)}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
@@ -23,12 +23,12 @@ function ScrollArea({
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
-  )
+  );
 }
 
 function ScrollBar({
   className,
-  orientation = "vertical",
+  orientation = 'vertical',
   ...props
 }: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
   return (
@@ -36,11 +36,11 @@ function ScrollBar({
       data-slot="scroll-area-scrollbar"
       orientation={orientation}
       className={cn(
-        "flex touch-none p-px transition-colors select-none",
-        orientation === "vertical" &&
-          "h-full w-2.5 border-l border-l-transparent",
-        orientation === "horizontal" &&
-          "h-2.5 flex-col border-t border-t-transparent",
+        'flex touch-none p-px transition-colors select-none',
+        orientation === 'vertical' &&
+          'h-full w-2.5 border-l border-l-transparent',
+        orientation === 'horizontal' &&
+          'h-2.5 flex-col border-t border-t-transparent',
         className
       )}
       {...props}
@@ -50,7 +50,7 @@ function ScrollBar({
         className="bg-border relative flex-1 rounded-full"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
-  )
+  );
 }
 
-export { ScrollArea, ScrollBar }
+export { ScrollArea, ScrollBar };

--- a/src/constants/dayOfWeekTranslations.ts
+++ b/src/constants/dayOfWeekTranslations.ts
@@ -1,0 +1,9 @@
+export const DAY_OF_WEEK_TRANSLATIONS: Record<string, string> = {
+  Monday: '月曜日',
+  Tuesday: '火曜日',
+  Wednesday: '水曜日',
+  Thursday: '木曜日',
+  Friday: '金曜日',
+  Saturday: '土曜日',
+  Sunday: '日曜日',
+};

--- a/src/constants/subjectTranslations.ts
+++ b/src/constants/subjectTranslations.ts
@@ -1,0 +1,42 @@
+import {
+  IconAlphabetLatin,
+  IconBook,
+  IconMap,
+  IconMathSymbols,
+  IconMicroscope,
+  type TablerIcon,
+} from '@tabler/icons-react';
+
+type SubjectTranslation = {
+  name: string;
+  icon: TablerIcon;
+  color: string;
+};
+
+export const SUBJECT_TRANSLATIONS: Record<string, SubjectTranslation> = {
+  Mathematics: {
+    name: '数学',
+    icon: IconMathSymbols,
+    color: 'bg-blue-100',
+  },
+  English: {
+    name: '英語',
+    icon: IconAlphabetLatin,
+    color: 'bg-purple-100',
+  },
+  Japanese: {
+    name: '国語',
+    icon: IconBook,
+    color: 'bg-red-100',
+  },
+  Science: {
+    name: '理科',
+    icon: IconMicroscope,
+    color: 'bg-green-100',
+  },
+  'Social Studies': {
+    name: '社会',
+    icon: IconMap,
+    color: 'bg-yellow-100',
+  },
+};

--- a/src/features/students/types/students.ts
+++ b/src/features/students/types/students.ts
@@ -4,7 +4,7 @@ type User = {
   uid: string;
   allow_password_change: boolean;
   name: string;
-  role: 'teacher' | 'admin';
+  role: string;
   school_stage: string | null;
   grade: number | null;
   graduated_university: string | null;
@@ -22,7 +22,7 @@ type Student = {
   status: string;
   joined_on: string;
   left_on: string | null;
-  school_stage: 'elementary_school' | 'junior_high_school' | 'high_school';
+  school_stage: string;
   grade: number;
   desired_school: string | null;
   created_at: string;

--- a/src/features/teachers/components/Table/Columns.tsx
+++ b/src/features/teachers/components/Table/Columns.tsx
@@ -1,0 +1,156 @@
+import { Button } from '@/components/ui/form/Button/button';
+import { Checkbox } from '@/components/ui/form/CheckBox/checkbox';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/navigation/DropdownMenu/dropdown-menu';
+import {
+  IconCircleCheckFilled,
+  IconDotsVertical,
+  IconLoader,
+  IconShieldStar,
+  IconUsers,
+} from '@tabler/icons-react';
+import type { ColumnDef } from '@tanstack/react-table';
+import { Badge } from '@/components/ui/display/Badge/badge';
+import { z } from 'zod';
+import { DetailDrawer } from './DetailDrawer';
+import type { teacherDetailDrawer } from '../../hooks/useFomatTeachersData';
+import { useSubjectTranslation } from '@/hooks/useSubjectTranslation';
+
+export const schema = z.object({
+  id: z.number(),
+  name: z.string(),
+  role: z.string(),
+  employStatus: z.string(),
+  classSubject: z.array(
+    z.object({
+      id: z.number(),
+      name: z.string(),
+    })
+  ),
+  studentsCount: z.number(),
+});
+
+// columns を関数として定義し、getDetailDrawerData を受け取る
+export const createColumns = (
+  getDetailDrawerData: (id: number) => teacherDetailDrawer | undefined
+): ColumnDef<z.infer<typeof schema>>[] => [
+  {
+    id: 'select',
+    header: ({ table }) => (
+      <div className="flex items-center justify-center px-4">
+        <Checkbox
+          checked={
+            table.getIsAllPageRowsSelected() ||
+            (table.getIsSomePageRowsSelected() && 'indeterminate')
+          }
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+          aria-label="Select all"
+        />
+      </div>
+    ),
+    cell: ({ row }) => (
+      <div className="flex items-center justify-center">
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(value) => row.toggleSelected(!!value)}
+          aria-label="Select row"
+        />
+      </div>
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: 'name',
+    header: '名前',
+    cell: ({ row }) => {
+      const detailData = getDetailDrawerData(row.original.id);
+      return detailData ? (
+        <DetailDrawer item={detailData} />
+      ) : (
+        <span>{row.original.name}</span>
+      );
+    },
+    enableHiding: false,
+  },
+  {
+    accessorKey: 'role',
+    header: '役割',
+    cell: ({ row }) => (
+      <div className="w-32">
+        <Badge variant="outline" className="text-muted-foreground px-1.5">
+          {row.original.role === 'admin' ? (
+            <IconShieldStar className="fill-blue-500" />
+          ) : (
+            <IconUsers className="fill-green-600" />
+          )}
+          {row.original.role}
+        </Badge>
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'employStatus',
+    header: '出勤状況',
+    cell: ({ row }) => (
+      <Badge variant="outline" className="text-muted-foreground px-1.5">
+        {/** Employ Status で分岐する */}
+        {row.original.employStatus === 'active' ? (
+          <IconCircleCheckFilled className="fill-green-500 dark:fill-green-400" />
+        ) : (
+          <IconLoader />
+        )}
+        {row.original.employStatus}
+      </Badge>
+    ),
+  },
+  {
+    accessorKey: 'classSubject',
+    header: '担当科目',
+    cell: ({ row }) => {
+      const { createIconTranslationBadge } = useSubjectTranslation();
+      const subjects = row.original.classSubject.map((cs) =>
+        createIconTranslationBadge(cs.name)
+      );
+      return <span>{subjects}</span>;
+    },
+  },
+
+  {
+    accessorKey: 'studentsCount',
+    header: '生徒数',
+    cell: ({ row }) => (
+      <Badge variant="outline" className="px-2">
+        {row.original.studentsCount} 名
+      </Badge>
+    ),
+  },
+  {
+    id: 'actions',
+    cell: () => (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            className="data-[state=open]:bg-muted text-muted-foreground flex size-8"
+            size="icon"
+          >
+            <IconDotsVertical />
+            <span className="sr-only">Open menu</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-32">
+          <DropdownMenuItem>編集</DropdownMenuItem>
+          <DropdownMenuItem>コピーを作成</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive">削除</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    ),
+  },
+];

--- a/src/features/teachers/components/Table/Columns.tsx
+++ b/src/features/teachers/components/Table/Columns.tsx
@@ -114,10 +114,10 @@ export const createColumns = (
     header: '担当科目',
     cell: ({ row }) => {
       const { createIconTranslationBadge } = useSubjectTranslation();
-      const subjects = row.original.classSubject.map((cs) =>
-        createIconTranslationBadge(cs.name)
-      );
-      return <span>{subjects}</span>;
+      const subjects = row.original.classSubject.map((cs) => (
+        <span key={cs.id}>{createIconTranslationBadge(cs.name)}</span>
+      ));
+      return subjects;
     },
   },
 

--- a/src/features/teachers/components/Table/DataTable.tsx
+++ b/src/features/teachers/components/Table/DataTable.tsx
@@ -1,0 +1,400 @@
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type UniqueIdentifier,
+} from '@dnd-kit/core';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import {
+  IconChevronDown,
+  IconChevronLeft,
+  IconChevronRight,
+  IconChevronsLeft,
+  IconChevronsRight,
+  IconLayoutColumns,
+  IconPlus,
+} from '@tabler/icons-react';
+import {
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import type {
+  ColumnFiltersState,
+  Row,
+  SortingState,
+  VisibilityState,
+} from '@tanstack/react-table';
+import { z } from 'zod';
+import { CSS } from '@dnd-kit/utilities';
+import { useId, useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/form/Button/button';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/navigation/DropdownMenu/dropdown-menu';
+import { Label } from '@/components/ui/form/Label/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/form/Select/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/display/Table/table';
+import { Tabs, TabsContent } from '@/components/ui/navigation/Tabs/tabs';
+
+import { schema, createColumns } from './Columns';
+import type { teacherDetailDrawer } from '../../hooks/useFomatTeachersData';
+
+function DraggableRow({ row }: { row: Row<z.infer<typeof schema>> }) {
+  const { transform, transition, setNodeRef, isDragging } = useSortable({
+    id: row.original.id,
+  });
+
+  return (
+    <TableRow
+      data-state={row.getIsSelected() && 'selected'}
+      data-dragging={isDragging}
+      ref={setNodeRef}
+      className="relative z-0 data-[dragging=true]:z-10 data-[dragging=true]:opacity-80"
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition: transition,
+      }}
+    >
+      {row.getVisibleCells().map((cell) => (
+        <TableCell key={cell.id}>
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </TableCell>
+      ))}
+    </TableRow>
+  );
+}
+
+// props に getDetailDrawerData を追加
+export const DataTable = ({
+  data: initialData,
+  getDetailDrawerData,
+}: {
+  data: z.infer<typeof schema>[];
+  getDetailDrawerData: (id: number) => teacherDetailDrawer | undefined;
+}) => {
+  const [data, setData] = useState(() => initialData);
+  const [rowSelection, setRowSelection] = useState({});
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+  const sortableId = useId();
+  const sensors = useSensors(
+    useSensor(MouseSensor, {}),
+    useSensor(TouchSensor, {}),
+    useSensor(KeyboardSensor, {})
+  );
+
+  const dataIds = useMemo<UniqueIdentifier[]>(
+    () => data?.map(({ id }) => id) || [],
+    [data]
+  );
+
+  // getDetailDrawerData をcreateColumnsに渡すためにuseMemoを使用
+  const columns = useMemo(
+    () => createColumns(getDetailDrawerData),
+    [getDetailDrawerData]
+  );
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      columnVisibility,
+      rowSelection,
+      columnFilters,
+      pagination,
+    },
+    getRowId: (row) => row.id.toString(),
+    enableRowSelection: true,
+    onRowSelectionChange: setRowSelection,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange: setColumnVisibility,
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+  });
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (active && over && active.id !== over.id) {
+      setData((data) => {
+        const oldIndex = dataIds.indexOf(active.id);
+        const newIndex = dataIds.indexOf(over.id);
+        return arrayMove(data, oldIndex, newIndex);
+      });
+    }
+  }
+
+  // カラム表示のラベルを定義
+  const columnLabelMap: Record<string, string> = {
+    name: '名前',
+    role: '役割',
+    employStatus: '出勤状況',
+    classSubject: '担当科目',
+    studentsCount: '生徒数',
+  };
+
+  return (
+    <Tabs
+      defaultValue="outline"
+      className="w-full flex-col justify-start gap-6"
+    >
+      <div className="flex items-center justify-between px-4 lg:px-6">
+        <Label htmlFor="view-selector" className="sr-only">
+          View
+        </Label>
+        {/** セレクター */}
+        <Select defaultValue="outline">
+          <SelectTrigger
+            className="flex w-fit @4xl/main:hidden"
+            size="sm"
+            id="view-selector"
+          >
+            <SelectValue placeholder="Select a view" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="outline">講師一覧</SelectItem>
+            <SelectItem value="past-performance">Coming Soon</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {/** カラムのカスタマイズとセクション追加ボタン */}
+        <div className="flex items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm">
+                <IconLayoutColumns />
+                <span className="hidden lg:inline">
+                  カラム表示のカスタマイズ
+                </span>
+                <span className="lg:hidden">カラムのカスタム</span>
+                <IconChevronDown />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              {table
+                .getAllColumns()
+                .filter(
+                  (column) =>
+                    typeof column.accessorFn !== 'undefined' &&
+                    column.getCanHide()
+                )
+                .map((column) => {
+                  return (
+                    <DropdownMenuCheckboxItem
+                      key={column.id}
+                      className="capitalize"
+                      checked={column.getIsVisible()}
+                      onCheckedChange={(value) =>
+                        column.toggleVisibility(!!value)
+                      }
+                    >
+                      {columnLabelMap[column.id] ?? column.id}
+                    </DropdownMenuCheckboxItem>
+                  );
+                })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button variant="outline" size="sm">
+            <IconPlus />
+            <span className="hidden lg:inline">講師の追加</span>
+          </Button>
+        </div>
+        {/** Outline タブの内容 */}
+      </div>
+      <TabsContent
+        value="outline"
+        className="relative flex flex-col gap-4 overflow-auto px-4 lg:px-6"
+      >
+        <div className="overflow-hidden rounded-lg border">
+          <DndContext
+            collisionDetection={closestCenter}
+            modifiers={[restrictToVerticalAxis]}
+            onDragEnd={handleDragEnd}
+            sensors={sensors}
+            id={sortableId}
+          >
+            <Table>
+              <TableHeader className="bg-muted sticky top-0 z-10">
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => {
+                      return (
+                        <TableHead key={header.id} colSpan={header.colSpan}>
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                              )}
+                        </TableHead>
+                      );
+                    })}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody className="**:data-[slot=table-cell]:first:w-8">
+                {table.getRowModel().rows?.length ? (
+                  <SortableContext
+                    items={dataIds}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    {table.getRowModel().rows.map((row) => (
+                      <DraggableRow key={row.id} row={row} />
+                    ))}
+                  </SortableContext>
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={columns.length}
+                      className="h-24 text-center"
+                    >
+                      No results.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </DndContext>
+        </div>
+        {/** ページネーションと選択状態の表示 */}
+        <div className="flex items-center justify-between px-4">
+          <div className="text-muted-foreground hidden flex-1 text-sm lg:flex">
+            {table.getFilteredSelectedRowModel().rows.length} of{' '}
+            {table.getFilteredRowModel().rows.length} row(s) selected.
+          </div>
+          <div className="flex w-full items-center gap-8 lg:w-fit">
+            <div className="hidden items-center gap-2 lg:flex">
+              <Label htmlFor="rows-per-page" className="text-sm font-medium">
+                1ページに表示する行数
+              </Label>
+              <Select
+                value={`${table.getState().pagination.pageSize}`}
+                onValueChange={(value) => {
+                  table.setPageSize(Number(value));
+                }}
+              >
+                <SelectTrigger size="sm" className="w-20" id="rows-per-page">
+                  <SelectValue
+                    placeholder={table.getState().pagination.pageSize}
+                  />
+                </SelectTrigger>
+                <SelectContent side="top">
+                  {[10, 20, 30, 40, 50].map((pageSize) => (
+                    <SelectItem key={pageSize} value={`${pageSize}`}>
+                      {pageSize}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex w-fit items-center justify-center text-sm font-medium">
+              Page {table.getState().pagination.pageIndex + 1} of{' '}
+              {table.getPageCount()}
+            </div>
+            <div className="ml-auto flex items-center gap-2 lg:ml-0">
+              <Button
+                variant="outline"
+                className="hidden h-8 w-8 p-0 lg:flex"
+                onClick={() => table.setPageIndex(0)}
+                disabled={!table.getCanPreviousPage()}
+              >
+                <span className="sr-only">最初のページへ</span>
+                <IconChevronsLeft />
+              </Button>
+              <Button
+                variant="outline"
+                className="size-8"
+                size="icon"
+                onClick={() => table.previousPage()}
+                disabled={!table.getCanPreviousPage()}
+              >
+                <span className="sr-only">前のページへ</span>
+                <IconChevronLeft />
+              </Button>
+              <Button
+                variant="outline"
+                className="size-8"
+                size="icon"
+                onClick={() => table.nextPage()}
+                disabled={!table.getCanNextPage()}
+              >
+                <span className="sr-only">次のページへ</span>
+                <IconChevronRight />
+              </Button>
+              <Button
+                variant="outline"
+                className="hidden size-8 lg:flex"
+                size="icon"
+                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+                disabled={!table.getCanNextPage()}
+              >
+                <span className="sr-only">最終ページへ</span>
+                <IconChevronsRight />
+              </Button>
+            </div>
+          </div>
+        </div>
+      </TabsContent>
+      <TabsContent
+        value="past-performance"
+        className="flex flex-col px-4 lg:px-6"
+      >
+        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
+      </TabsContent>
+      <TabsContent value="key-personnel" className="flex flex-col px-4 lg:px-6">
+        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
+      </TabsContent>
+      <TabsContent
+        value="focus-documents"
+        className="flex flex-col px-4 lg:px-6"
+      >
+        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
+      </TabsContent>
+    </Tabs>
+  );
+};

--- a/src/features/teachers/components/Table/DetailDrawer.tsx
+++ b/src/features/teachers/components/Table/DetailDrawer.tsx
@@ -13,6 +13,7 @@ import { Badge } from '@/components/ui/display/Badge/badge';
 import { IconCircleCheckFilled, IconLoader } from '@tabler/icons-react';
 import { useSubjectTranslation } from '@/hooks/useSubjectTranslation';
 import { useDayOfWeekTranslation } from '@/hooks/useDayOfWeekTranslation';
+import { Fragment } from 'react/jsx-runtime';
 
 export const DetailDrawer = ({ item }: { item: teacherDetailDrawer }) => {
   const isMobile = useIsMobile();
@@ -66,9 +67,11 @@ export const DetailDrawer = ({ item }: { item: teacherDetailDrawer }) => {
           <div className="flex flex-col gap-2">
             <Label htmlFor="subjects">担当科目</Label>
             <div id="subjects" className="flex flex-wrap gap-2">
-              {item.classSubject.map((cs) =>
-                createIconTranslationBadge(cs.name)
-              )}
+              {item.classSubject.map((cs) => (
+                <Fragment key={cs.id}>
+                  {createIconTranslationBadge(cs.name)}
+                </Fragment>
+              ))}
             </div>
           </div>
           <div className="flex flex-col gap-2">

--- a/src/features/teachers/components/Table/DetailDrawer.tsx
+++ b/src/features/teachers/components/Table/DetailDrawer.tsx
@@ -1,0 +1,115 @@
+import { Button } from '@/components/ui/form/Button/button';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/layout/Drawer/drawer';
+import { Label } from '@/components/ui/form/Label/label';
+import type { teacherDetailDrawer } from '../../hooks/useFomatTeachersData';
+import { useIsMobile } from '@/hooks/useMobile';
+import { Badge } from '@/components/ui/display/Badge/badge';
+import { IconCircleCheckFilled, IconLoader } from '@tabler/icons-react';
+import { useSubjectTranslation } from '@/hooks/useSubjectTranslation';
+import { useDayOfWeekTranslation } from '@/hooks/useDayOfWeekTranslation';
+
+export const DetailDrawer = ({ item }: { item: teacherDetailDrawer }) => {
+  const isMobile = useIsMobile();
+  const { createIconTranslationBadge } = useSubjectTranslation();
+  const { translate } = useDayOfWeekTranslation();
+
+  return (
+    <Drawer direction={isMobile ? 'bottom' : 'right'}>
+      <DrawerTrigger asChild>
+        <Button variant="link" className="text-foreground w-fit px-0 text-left">
+          {item.name}
+        </Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader className="gap-1">
+          <DrawerTitle>講師の詳細情報</DrawerTitle>
+        </DrawerHeader>
+        <div className="flex flex-col gap-4 overflow-y-auto px-4 py-2 text-sm">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="name">名前</Label>
+            <p id="name" className="text-muted-foreground">
+              {item.name}
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="email">メール</Label>
+            <p id="email" className="text-muted-foreground">
+              {item.email}
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="role">役割</Label>
+            <p id="role" className="text-muted-foreground">
+              {item.role}
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="employStatus">出勤状況</Label>
+            <Badge
+              variant="outline"
+              className="text-muted-foreground px-1.5 gap-1"
+            >
+              {item.employStatus === 'active' ? (
+                <IconCircleCheckFilled className="h-4 w-4 fill-green-500 dark:fill-green-400" />
+              ) : (
+                <IconLoader className="h-4 w-4" />
+              )}
+              {item.employStatus}
+            </Badge>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="subjects">担当科目</Label>
+            <div id="subjects" className="flex flex-wrap gap-2">
+              {item.classSubject.map((cs) =>
+                createIconTranslationBadge(cs.name)
+              )}
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="studentList">担当生徒</Label>
+            <p id="studentList" className="text-muted-foreground">
+              {item.Students.map((s) => s.name).join(', ')}
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="lastLogin">最終ログイン</Label>
+            <p id="lastLogin" className="text-muted-foreground">
+              {item.last_sign_in_at}
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="currentLogin">現在のログイン状況</Label>
+            <Badge
+              variant="outline"
+              className="text-muted-foreground px-1.5 gap-1"
+            >
+              {item.current_sign_in_at !== null ? (
+                <>
+                  <IconCircleCheckFilled className="h-4 w-4 fill-green-500 dark:fill-green-400" />
+                  <span>ログイン中</span>
+                </>
+              ) : (
+                <>
+                  <IconLoader className="h-4 w-4" />
+                  <span>未ログイン</span>
+                </>
+              )}
+            </Badge>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="availableDays">勤務可能日</Label>
+            <p id="availableDays" className="text-muted-foreground">
+              {item.available_days.map((day) => translate(day.name)).join(', ')}
+            </p>
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/src/features/teachers/components/Table/currentUser.json
+++ b/src/features/teachers/components/Table/currentUser.json
@@ -1,0 +1,43 @@
+{
+  "id": 1,
+  "name": "山田 太郎",
+  "role": "admin",
+  "email": "yamada.taro@example.com",
+  "school_id": 1,
+  "employStatus": "active",
+  "last_sign_in_at": "2025-08-01T12:00:00Z",
+  "current_sign_in_at": null,
+  "created_at": "2025-01-01T12:00:00Z",
+  "available_days": [
+    {
+      "id": 1,
+      "name": "Monday"
+    },
+    {
+      "id": 2,
+      "name": "Tuesday"
+    }
+  ],
+  "classSubject": [
+    {
+      "id": 1,
+      "name": "Mathematics"
+    },
+    {
+      "id": 2,
+      "name": "English"
+    }
+  ],
+  "Students": [
+    {
+      "id": 1,
+      "student_code": "S001",
+      "name": "佐藤 花子"
+    },
+    {
+      "id": 2,
+      "student_code": "S002",
+      "name": "鈴木 次郎"
+    }
+  ]
+}

--- a/src/features/teachers/components/Table/index.ts
+++ b/src/features/teachers/components/Table/index.ts
@@ -1,0 +1,3 @@
+export * from './DataTable';
+export * from './Columns';
+export * from './DetailDrawer';

--- a/src/features/teachers/components/Table/teachers.json
+++ b/src/features/teachers/components/Table/teachers.json
@@ -1,0 +1,1225 @@
+[
+  {
+    "id": 3,
+    "name": "中村 太郎",
+    "role": "teacher",
+    "email": "teacher01@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-07-05T14:04:53Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-01T12:00:00Z",
+    "available_days": [
+      {
+        "id": 2,
+        "name": "Tuesday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 1,
+        "name": "English"
+      }
+    ],
+    "Students": [
+      {
+        "id": 3,
+        "student_code": "S0003",
+        "name": "渡辺 未来"
+      },
+      {
+        "id": 4,
+        "student_code": "S0004",
+        "name": "中島 花子"
+      },
+      {
+        "id": 5,
+        "student_code": "S0005",
+        "name": "鈴木 健"
+      },
+      {
+        "id": 6,
+        "student_code": "S0006",
+        "name": "山口 さくら"
+      }
+    ]
+  },
+  {
+    "id": 4,
+    "name": "鈴木 光",
+    "role": "teacher",
+    "email": "teacher02@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-07-21T06:20:21Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-02T12:00:00Z",
+    "available_days": [
+      {
+        "id": 6,
+        "name": "Saturday"
+      },
+      {
+        "id": 7,
+        "name": "Sunday"
+      },
+      {
+        "id": 5,
+        "name": "Friday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 2,
+        "name": "Japanese"
+      },
+      {
+        "id": 4,
+        "name": "Science"
+      }
+    ],
+    "Students": [
+      {
+        "id": 7,
+        "student_code": "S0007",
+        "name": "林 花"
+      },
+      {
+        "id": 8,
+        "student_code": "S0008",
+        "name": "佐藤 颯"
+      },
+      {
+        "id": 9,
+        "student_code": "S0009",
+        "name": "吉田 海斗"
+      },
+      {
+        "id": 10,
+        "student_code": "S0010",
+        "name": "中島 悠"
+      }
+    ]
+  },
+  {
+    "id": 5,
+    "name": "山口 颯",
+    "role": "teacher",
+    "email": "teacher03@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-07-08T16:28:36Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-03T12:00:00Z",
+    "available_days": [
+      {
+        "id": 1,
+        "name": "Monday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 1,
+        "name": "English"
+      },
+      {
+        "id": 3,
+        "name": "Mathematics"
+      }
+    ],
+    "Students": [
+      {
+        "id": 11,
+        "student_code": "S0011",
+        "name": "金子 大輔"
+      },
+      {
+        "id": 12,
+        "student_code": "S0012",
+        "name": "高橋 美咲"
+      }
+    ]
+  },
+  {
+    "id": 6,
+    "name": "中村 葵",
+    "role": "teacher",
+    "email": "teacher04@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-06-14T03:31:28Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-04T12:00:00Z",
+    "available_days": [
+      {
+        "id": 5,
+        "name": "Friday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 5,
+        "name": "Social Studies"
+      },
+      {
+        "id": 3,
+        "name": "Mathematics"
+      }
+    ],
+    "Students": [
+      {
+        "id": 13,
+        "student_code": "S0013",
+        "name": "佐々木 海斗"
+      },
+      {
+        "id": 14,
+        "student_code": "S0014",
+        "name": "伊藤 花子"
+      },
+      {
+        "id": 15,
+        "student_code": "S0015",
+        "name": "松本 颯"
+      },
+      {
+        "id": 16,
+        "student_code": "S0016",
+        "name": "斎藤 健"
+      }
+    ]
+  },
+  {
+    "id": 7,
+    "name": "山本 萌",
+    "role": "teacher",
+    "email": "teacher05@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-06-08T12:24:21Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-05T12:00:00Z",
+    "available_days": [
+      {
+        "id": 6,
+        "name": "Saturday"
+      },
+      {
+        "id": 3,
+        "name": "Wednesday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 3,
+        "name": "Mathematics"
+      }
+    ],
+    "Students": [
+      {
+        "id": 17,
+        "student_code": "S0017",
+        "name": "山口 蒼"
+      },
+      {
+        "id": 18,
+        "student_code": "S0018",
+        "name": "林 海斗"
+      }
+    ]
+  },
+  {
+    "id": 8,
+    "name": "伊藤 涼",
+    "role": "teacher",
+    "email": "teacher06@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-07-17T21:23:39Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-06T12:00:00Z",
+    "available_days": [
+      {
+        "id": 6,
+        "name": "Saturday"
+      },
+      {
+        "id": 2,
+        "name": "Tuesday"
+      },
+      {
+        "id": 7,
+        "name": "Sunday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 4,
+        "name": "Science"
+      },
+      {
+        "id": 3,
+        "name": "Mathematics"
+      }
+    ],
+    "Students": [
+      {
+        "id": 19,
+        "student_code": "S0019",
+        "name": "松本 蒼"
+      },
+      {
+        "id": 20,
+        "student_code": "S0020",
+        "name": "山崎 太一"
+      },
+      {
+        "id": 21,
+        "student_code": "S0021",
+        "name": "田中 さくら"
+      },
+      {
+        "id": 22,
+        "student_code": "S0022",
+        "name": "高橋 花"
+      }
+    ]
+  },
+  {
+    "id": 9,
+    "name": "林 健",
+    "role": "teacher",
+    "email": "teacher07@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-07-21T14:42:58Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-07T12:00:00Z",
+    "available_days": [
+      {
+        "id": 6,
+        "name": "Saturday"
+      },
+      {
+        "id": 3,
+        "name": "Wednesday"
+      },
+      {
+        "id": 2,
+        "name": "Tuesday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 4,
+        "name": "Science"
+      },
+      {
+        "id": 5,
+        "name": "Social Studies"
+      },
+      {
+        "id": 3,
+        "name": "Mathematics"
+      }
+    ],
+    "Students": [
+      {
+        "id": 23,
+        "student_code": "S0023",
+        "name": "加藤 大輔"
+      },
+      {
+        "id": 24,
+        "student_code": "S0024",
+        "name": "小林 さくら"
+      },
+      {
+        "id": 25,
+        "student_code": "S0025",
+        "name": "青木 光"
+      }
+    ]
+  },
+  {
+    "id": 10,
+    "name": "中島 心",
+    "role": "teacher",
+    "email": "teacher08@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-07-28T13:09:20Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-08T12:00:00Z",
+    "available_days": [
+      {
+        "id": 2,
+        "name": "Tuesday"
+      },
+      {
+        "id": 7,
+        "name": "Sunday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 4,
+        "name": "Science"
+      },
+      {
+        "id": 1,
+        "name": "English"
+      },
+      {
+        "id": 5,
+        "name": "Social Studies"
+      }
+    ],
+    "Students": []
+  },
+  {
+    "id": 11,
+    "name": "吉田 花",
+    "role": "teacher",
+    "email": "teacher09@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-06-25T07:49:46Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-09T12:00:00Z",
+    "available_days": [
+      {
+        "id": 1,
+        "name": "Monday"
+      },
+      {
+        "id": 4,
+        "name": "Thursday"
+      },
+      {
+        "id": 6,
+        "name": "Saturday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 4,
+        "name": "Science"
+      },
+      {
+        "id": 3,
+        "name": "Mathematics"
+      },
+      {
+        "id": 5,
+        "name": "Social Studies"
+      }
+    ],
+    "Students": []
+  },
+  {
+    "id": 12,
+    "name": "村上 颯",
+    "role": "teacher",
+    "email": "teacher10@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-06-22T02:24:38Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-10T12:00:00Z",
+    "available_days": [
+      {
+        "id": 3,
+        "name": "Wednesday"
+      },
+      {
+        "id": 1,
+        "name": "Monday"
+      },
+      {
+        "id": 7,
+        "name": "Sunday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 2,
+        "name": "Japanese"
+      },
+      {
+        "id": 4,
+        "name": "Science"
+      }
+    ],
+    "Students": []
+  },
+  {
+    "id": 13,
+    "name": "長谷川 颯",
+    "role": "teacher",
+    "email": "teacher11@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-08-06T14:11:36Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-11T12:00:00Z",
+    "available_days": [
+      {
+        "id": 1,
+        "name": "Monday"
+      },
+      {
+        "id": 6,
+        "name": "Saturday"
+      },
+      {
+        "id": 3,
+        "name": "Wednesday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 5,
+        "name": "Social Studies"
+      },
+      {
+        "id": 2,
+        "name": "Japanese"
+      },
+      {
+        "id": 1,
+        "name": "English"
+      }
+    ],
+    "Students": [
+      {
+        "id": 26,
+        "student_code": "S0026",
+        "name": "吉田 光"
+      },
+      {
+        "id": 27,
+        "student_code": "S0027",
+        "name": "近藤 葵"
+      }
+    ]
+  },
+  {
+    "id": 14,
+    "name": "山崎 里奈",
+    "role": "teacher",
+    "email": "teacher12@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-08-01T18:18:21Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-12T12:00:00Z",
+    "available_days": [
+      {
+        "id": 3,
+        "name": "Wednesday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 2,
+        "name": "Japanese"
+      },
+      {
+        "id": 1,
+        "name": "English"
+      }
+    ],
+    "Students": [
+      {
+        "id": 28,
+        "student_code": "S0028",
+        "name": "新垣 健"
+      }
+    ]
+  },
+  {
+    "id": 15,
+    "name": "伊藤 颯",
+    "role": "teacher",
+    "email": "teacher13@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-07-24T16:21:54Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-13T12:00:00Z",
+    "available_days": [
+      {
+        "id": 6,
+        "name": "Saturday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 5,
+        "name": "Social Studies"
+      },
+      {
+        "id": 2,
+        "name": "Japanese"
+      }
+    ],
+    "Students": [
+      {
+        "id": 29,
+        "student_code": "S0029",
+        "name": "近藤 光希"
+      },
+      {
+        "id": 30,
+        "student_code": "S0030",
+        "name": "金子 隼"
+      }
+    ]
+  },
+  {
+    "id": 16,
+    "name": "佐々木 海斗",
+    "role": "teacher",
+    "email": "teacher14@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-07-23T03:49:09Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-14T12:00:00Z",
+    "available_days": [
+      {
+        "id": 6,
+        "name": "Saturday"
+      },
+      {
+        "id": 7,
+        "name": "Sunday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 4,
+        "name": "Science"
+      },
+      {
+        "id": 5,
+        "name": "Social Studies"
+      }
+    ],
+    "Students": []
+  },
+  {
+    "id": 17,
+    "name": "伊藤 悠",
+    "role": "teacher",
+    "email": "teacher15@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-06-22T13:01:21Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-15T12:00:00Z",
+    "available_days": [
+      {
+        "id": 5,
+        "name": "Friday"
+      },
+      {
+        "id": 2,
+        "name": "Tuesday"
+      },
+      {
+        "id": 7,
+        "name": "Sunday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 1,
+        "name": "English"
+      }
+    ],
+    "Students": []
+  },
+  {
+    "id": 18,
+    "name": "田中 さくら",
+    "role": "teacher",
+    "email": "teacher16@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-06-21T15:12:33Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-16T12:00:00Z",
+    "available_days": [
+      {
+        "id": 7,
+        "name": "Sunday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 1,
+        "name": "English"
+      },
+      {
+        "id": 2,
+        "name": "Japanese"
+      }
+    ],
+    "Students": [
+      {
+        "id": 31,
+        "student_code": "S0031",
+        "name": "岡田 悠真"
+      },
+      {
+        "id": 32,
+        "student_code": "S0032",
+        "name": "村上 直樹"
+      }
+    ]
+  },
+  {
+    "id": 19,
+    "name": "新垣 里奈",
+    "role": "teacher",
+    "email": "teacher17@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-06-25T20:18:22Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-17T12:00:00Z",
+    "available_days": [
+      {
+        "id": 7,
+        "name": "Sunday"
+      },
+      {
+        "id": 4,
+        "name": "Thursday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 1,
+        "name": "English"
+      }
+    ],
+    "Students": []
+  },
+  {
+    "id": 20,
+    "name": "森 隼",
+    "role": "teacher",
+    "email": "teacher18@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-07-12T23:38:47Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-18T12:00:00Z",
+    "available_days": [
+      {
+        "id": 7,
+        "name": "Sunday"
+      },
+      {
+        "id": 6,
+        "name": "Saturday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 1,
+        "name": "English"
+      }
+    ],
+    "Students": []
+  },
+  {
+    "id": 21,
+    "name": "山本 さくら",
+    "role": "teacher",
+    "email": "teacher19@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-07-23T09:15:20Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-19T12:00:00Z",
+    "available_days": [
+      {
+        "id": 5,
+        "name": "Friday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 2,
+        "name": "Japanese"
+      },
+      {
+        "id": 4,
+        "name": "Science"
+      }
+    ],
+    "Students": [
+      {
+        "id": 33,
+        "student_code": "S0033",
+        "name": "林 春菜"
+      }
+    ]
+  },
+  {
+    "id": 22,
+    "name": "前田 花",
+    "role": "teacher",
+    "email": "teacher20@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-07-08T04:13:04Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-20T12:00:00Z",
+    "available_days": [
+      {
+        "id": 6,
+        "name": "Saturday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 1,
+        "name": "English"
+      },
+      {
+        "id": 5,
+        "name": "Social Studies"
+      },
+      {
+        "id": 4,
+        "name": "Science"
+      }
+    ],
+    "Students": [
+      {
+        "id": 34,
+        "student_code": "S0034",
+        "name": "石川 里奈"
+      }
+    ]
+  },
+  {
+    "id": 23,
+    "name": "山下 心",
+    "role": "teacher",
+    "email": "teacher21@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-06-21T15:45:55Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-21T12:00:00Z",
+    "available_days": [
+      {
+        "id": 4,
+        "name": "Thursday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 4,
+        "name": "Science"
+      }
+    ],
+    "Students": [
+      {
+        "id": 35,
+        "student_code": "S0035",
+        "name": "藤田 真由"
+      },
+      {
+        "id": 36,
+        "student_code": "S0036",
+        "name": "中島 海斗"
+      }
+    ]
+  },
+  {
+    "id": 24,
+    "name": "岡田 直樹",
+    "role": "teacher",
+    "email": "teacher22@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-07-05T16:39:45Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-22T12:00:00Z",
+    "available_days": [
+      {
+        "id": 2,
+        "name": "Tuesday"
+      },
+      {
+        "id": 1,
+        "name": "Monday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 5,
+        "name": "Social Studies"
+      },
+      {
+        "id": 1,
+        "name": "English"
+      },
+      {
+        "id": 3,
+        "name": "Mathematics"
+      }
+    ],
+    "Students": [
+      {
+        "id": 37,
+        "student_code": "S0037",
+        "name": "田中 花子"
+      },
+      {
+        "id": 38,
+        "student_code": "S0038",
+        "name": "上原 里奈"
+      }
+    ]
+  },
+  {
+    "id": 25,
+    "name": "吉田 花子",
+    "role": "teacher",
+    "email": "teacher23@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-06-07T15:15:32Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-23T12:00:00Z",
+    "available_days": [
+      {
+        "id": 1,
+        "name": "Monday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 1,
+        "name": "English"
+      },
+      {
+        "id": 2,
+        "name": "Japanese"
+      },
+      {
+        "id": 4,
+        "name": "Science"
+      }
+    ],
+    "Students": []
+  },
+  {
+    "id": 26,
+    "name": "井上 未来",
+    "role": "teacher",
+    "email": "teacher24@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-07-21T21:35:24Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-24T12:00:00Z",
+    "available_days": [
+      {
+        "id": 1,
+        "name": "Monday"
+      },
+      {
+        "id": 4,
+        "name": "Thursday"
+      },
+      {
+        "id": 5,
+        "name": "Friday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 5,
+        "name": "Social Studies"
+      },
+      {
+        "id": 3,
+        "name": "Mathematics"
+      },
+      {
+        "id": 2,
+        "name": "Japanese"
+      }
+    ],
+    "Students": [
+      {
+        "id": 39,
+        "student_code": "S0039",
+        "name": "山崎 さくら"
+      }
+    ]
+  },
+  {
+    "id": 27,
+    "name": "小林 蒼",
+    "role": "teacher",
+    "email": "teacher25@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-06-08T23:17:35Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-25T12:00:00Z",
+    "available_days": [
+      {
+        "id": 3,
+        "name": "Wednesday"
+      },
+      {
+        "id": 1,
+        "name": "Monday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 4,
+        "name": "Science"
+      }
+    ],
+    "Students": [
+      {
+        "id": 40,
+        "student_code": "S0040",
+        "name": "新垣 結衣"
+      },
+      {
+        "id": 41,
+        "student_code": "S0041",
+        "name": "伊藤 光"
+      },
+      {
+        "id": 42,
+        "student_code": "S0042",
+        "name": "山口 大地"
+      },
+      {
+        "id": 43,
+        "student_code": "S0043",
+        "name": "木村 直樹"
+      }
+    ]
+  },
+  {
+    "id": 28,
+    "name": "伊藤 心",
+    "role": "teacher",
+    "email": "teacher26@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-07-31T08:06:11Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-26T12:00:00Z",
+    "available_days": [
+      {
+        "id": 3,
+        "name": "Wednesday"
+      },
+      {
+        "id": 2,
+        "name": "Tuesday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 5,
+        "name": "Social Studies"
+      },
+      {
+        "id": 3,
+        "name": "Mathematics"
+      }
+    ],
+    "Students": [
+      {
+        "id": 44,
+        "student_code": "S0044",
+        "name": "近藤 太郎"
+      },
+      {
+        "id": 45,
+        "student_code": "S0045",
+        "name": "青木 真由"
+      },
+      {
+        "id": 46,
+        "student_code": "S0046",
+        "name": "山本 心"
+      },
+      {
+        "id": 47,
+        "student_code": "S0047",
+        "name": "小林 大輔"
+      }
+    ]
+  },
+  {
+    "id": 29,
+    "name": "青木 直樹",
+    "role": "teacher",
+    "email": "teacher27@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-06-10T10:09:02Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-27T12:00:00Z",
+    "available_days": [
+      {
+        "id": 5,
+        "name": "Friday"
+      },
+      {
+        "id": 2,
+        "name": "Tuesday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 3,
+        "name": "Mathematics"
+      },
+      {
+        "id": 2,
+        "name": "Japanese"
+      },
+      {
+        "id": 5,
+        "name": "Social Studies"
+      }
+    ],
+    "Students": [
+      {
+        "id": 48,
+        "student_code": "S0048",
+        "name": "長谷川 里奈"
+      },
+      {
+        "id": 49,
+        "student_code": "S0049",
+        "name": "木村 心"
+      }
+    ]
+  },
+  {
+    "id": 30,
+    "name": "渡辺 菜々",
+    "role": "teacher",
+    "email": "teacher28@example.com",
+    "school_id": 1,
+    "employStatus": "inactive",
+    "last_sign_in_at": "2025-06-22T20:25:43Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-28T12:00:00Z",
+    "available_days": [
+      {
+        "id": 1,
+        "name": "Monday"
+      },
+      {
+        "id": 7,
+        "name": "Sunday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 2,
+        "name": "Japanese"
+      },
+      {
+        "id": 3,
+        "name": "Mathematics"
+      }
+    ],
+    "Students": [
+      {
+        "id": 50,
+        "student_code": "S0050",
+        "name": "前田 光"
+      }
+    ]
+  },
+  {
+    "id": 31,
+    "name": "青木 太郎",
+    "role": "teacher",
+    "email": "teacher29@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-06-14T22:33:27Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-29T12:00:00Z",
+    "available_days": [
+      {
+        "id": 6,
+        "name": "Saturday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 5,
+        "name": "Social Studies"
+      }
+    ],
+    "Students": []
+  },
+  {
+    "id": 32,
+    "name": "上原 光",
+    "role": "teacher",
+    "email": "teacher30@example.com",
+    "school_id": 1,
+    "employStatus": "active",
+    "last_sign_in_at": "2025-07-31T23:07:23Z",
+    "current_sign_in_at": null,
+    "created_at": "2025-01-30T12:00:00Z",
+    "available_days": [
+      {
+        "id": 2,
+        "name": "Tuesday"
+      },
+      {
+        "id": 1,
+        "name": "Monday"
+      }
+    ],
+    "classSubject": [
+      {
+        "id": 3,
+        "name": "Mathematics"
+      },
+      {
+        "id": 1,
+        "name": "English"
+      }
+    ],
+    "Students": [
+      {
+        "id": 51,
+        "student_code": "S0051",
+        "name": "山口 蒼"
+      },
+      {
+        "id": 52,
+        "student_code": "S0052",
+        "name": "井上 蒼"
+      }
+    ]
+  }
+]

--- a/src/features/teachers/hooks/useFomatTeachersData.ts
+++ b/src/features/teachers/hooks/useFomatTeachersData.ts
@@ -1,0 +1,136 @@
+import currentUser from '../components/Table/currentUser.json';
+import teachers from '../components/Table/teachers.json';
+
+type teacherDataTable = {
+  id: number;
+  name: string;
+  role: string;
+  employStatus: string;
+  classSubject: {
+    id: number;
+    name: string;
+  }[];
+  studentsCount: number;
+};
+
+type teacherDetailDrawer = {
+  id: number;
+  name: string;
+  email: string;
+  role: string;
+  employStatus: string;
+  last_sign_in_at: string;
+  current_sign_in_at: string;
+  created_at: string;
+  available_days: {
+    id: number;
+    name: string;
+  }[];
+  classSubject: {
+    id: number;
+    name: string;
+  }[];
+  Students: {
+    id: number;
+    student_code: string;
+    name: string;
+  }[];
+};
+
+type fetchData = {
+  id: number;
+  name: string;
+  role: string;
+  email: string;
+  school_id: number | null;
+  employStatus: string;
+  last_sign_in_at: string;
+  current_sign_in_at: string | null;
+  created_at: string;
+  available_days: {
+    id: number;
+    name: string;
+  }[];
+  classSubject: {
+    id: number;
+    name: string;
+  }[];
+  Students: {
+    id: number;
+    student_code: string;
+    name: string;
+  }[];
+};
+
+export type { teacherDataTable, teacherDetailDrawer };
+
+const toTeacherRow = (teacher: fetchData): teacherDataTable => ({
+  id: teacher.id,
+  name: teacher.name,
+  role: teacher.role,
+  employStatus: teacher.employStatus,
+  classSubject: teacher.classSubject.map((cs) => ({
+    id: cs.id,
+    name: cs.name,
+  })),
+  studentsCount: teacher.Students.length,
+});
+
+const toTeacherDetailDrawer = (teacher: fetchData): teacherDetailDrawer => ({
+  id: teacher.id,
+  name: teacher.name,
+  email: teacher.email,
+  role: teacher.role,
+  employStatus: teacher.employStatus,
+  last_sign_in_at: teacher.last_sign_in_at,
+  current_sign_in_at: teacher.current_sign_in_at || '',
+  created_at: teacher.created_at,
+  available_days: teacher.available_days.map((day) => ({
+    id: day.id,
+    name: day.name,
+  })),
+  classSubject: teacher.classSubject.map((cs) => ({
+    id: cs.id,
+    name: cs.name,
+  })),
+  Students: teacher.Students.map((student) => ({
+    id: student.id,
+    student_code: student.student_code,
+    name: student.name,
+  })),
+});
+
+export const useFormatTeachersData = () => {
+  // currentUser と teachers のデータを成形して返す
+  const currentUserData: fetchData[] = Array.isArray(currentUser)
+    ? currentUser
+    : [currentUser];
+  const currentUserDataTable: teacherDataTable[] =
+    currentUserData.map(toTeacherRow);
+  const teachersDataTable: teacherDataTable[] = teachers.map(toTeacherRow);
+  const dataTable: teacherDataTable[] = [
+    ...currentUserDataTable,
+    ...teachersDataTable,
+  ];
+
+  // currentUser と teachers の詳細データを成形して返す
+  const currentUserDetailData: fetchData[] = Array.isArray(currentUser)
+    ? currentUser
+    : [currentUser];
+  const currentUserDetailDrawer: teacherDetailDrawer[] =
+    currentUserDetailData.map(toTeacherDetailDrawer);
+  const teachersDetailDrawer: teacherDetailDrawer[] = teachers.map(
+    toTeacherDetailDrawer
+  );
+  const detailDrawer: teacherDetailDrawer[] = [
+    ...currentUserDetailDrawer,
+    ...teachersDetailDrawer,
+  ];
+
+  // ID でdetailDrawer のデータを検索する関数を追加
+  const getDetailDrawerData = (id: number): teacherDetailDrawer | undefined => {
+    return detailDrawer.find((item) => item.id === id);
+  };
+
+  return { dataTable, getDetailDrawerData };
+};

--- a/src/hooks/useDayOfWeekTranslation.tsx
+++ b/src/hooks/useDayOfWeekTranslation.tsx
@@ -1,0 +1,7 @@
+import { DAY_OF_WEEK_TRANSLATIONS } from '@/constants/dayOfWeekTranslations';
+
+export const useDayOfWeekTranslation = () => {
+  const translate = (en: string) => DAY_OF_WEEK_TRANSLATIONS[en] ?? en;
+
+  return { translate };
+};

--- a/src/hooks/useSubjectTranslation.tsx
+++ b/src/hooks/useSubjectTranslation.tsx
@@ -1,0 +1,22 @@
+// hooks/useSubjectTranslation.ts
+import { Badge } from '@/components/ui/display/Badge/badge';
+import { SUBJECT_TRANSLATIONS } from '@/constants/subjectTranslations';
+
+export const useSubjectTranslation = () => {
+  const translate = (en: string) => SUBJECT_TRANSLATIONS[en]?.name ?? en;
+
+  const createIconTranslationBadge = (en: string) => {
+    const meta = SUBJECT_TRANSLATIONS[en];
+    const Icon = meta?.icon;
+    return (
+      <Badge
+        variant="outline"
+        className={`text-muted-foreground px-1.5 mx-1 ${meta.color}`}
+      >
+        {Icon ? <Icon /> : <span>{translate(en)}</span>}
+        {translate(en)}
+      </Badge>
+    );
+  };
+  return { translate, createIconTranslationBadge };
+};

--- a/src/hooks/useSubjectTranslation.tsx
+++ b/src/hooks/useSubjectTranslation.tsx
@@ -1,4 +1,3 @@
-// hooks/useSubjectTranslation.ts
 import { Badge } from '@/components/ui/display/Badge/badge';
 import { SUBJECT_TRANSLATIONS } from '@/constants/subjectTranslations';
 
@@ -11,7 +10,7 @@ export const useSubjectTranslation = () => {
     return (
       <Badge
         variant="outline"
-        className={`text-muted-foreground px-1.5 mx-1 ${meta.color}`}
+        className={`text-muted-foreground px-1.5 mx-1 ${meta?.color ?? ''}`}
       >
         {Icon ? <Icon /> : <span>{translate(en)}</span>}
         {translate(en)}

--- a/src/pages/teachers/TeachersPage.tsx
+++ b/src/pages/teachers/TeachersPage.tsx
@@ -1,48 +1,14 @@
+import { DataTable } from '@/features/teachers/components/Table';
 import { useFetchTeachers } from '@/features/teachers/hooks/useFetchTeachers';
+import { useFormatTeachersData } from '@/features/teachers/hooks/useFomatTeachersData';
 
 export const TeachersPage = () => {
-  const { currentUser, teachers, error } = useFetchTeachers();
+  const { dataTable, getDetailDrawerData } = useFormatTeachersData();
+  const { error } = useFetchTeachers();
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">教師管理</h1>
-      <p className="text-muted-foreground mb-6">
-        教師の情報を管理するためのセクションです。
-      </p>
-      {/* 教師管理のコンテンツをここに追加 */}
-      {error && <p className="text-red-500 mb-4">エラー: {error}</p>}
-      {currentUser && (
-        <div className="mb-4">
-          <h2 className="text-xl font-semibold">現在のユーザー</h2>
-          <p>名前: {currentUser.name}</p>
-          <p>メール: {currentUser.email}</p>
-          <p>
-            {currentUser.students.map((student) => (
-              <span key={student.id}>
-                {student.student_code} - {student.name}
-              </span>
-            ))}
-          </p>
-        </div>
-      )}
-      {teachers && teachers.length > 0 ? (
-        <div>
-          <h2 className="text-xl font-semibold">教師一覧</h2>
-          <ul className="list-disc pl-5">
-            {teachers.map((teacher) => (
-              <li key={teacher.id}>
-                {teacher.name} ({teacher.email})<br />
-                {teacher.students.map((student) => (
-                  <span key={student.id}>
-                    {student.student_code} - {student.name}
-                  </span>
-                ))}
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : (
-        <p>教師が登録されていません。</p>
-      )}
+      {error && <div className="text-red-500 mb-4">{error}</div>}
+      <DataTable data={dataTable} getDetailDrawerData={getDetailDrawerData} />
     </div>
   );
 };


### PR DESCRIPTION
## ISSUE

close #53 
## 実装概要

<!-- この PR の目的・背景を 1～2 行で記載してください（例：バグ修正、UI改善、パフォーマンス向上など） -->
- 教師管理ページ（`TeachersPage`）のUIを刷新し、`DataTable`による一覧表示に変更
- ダミーデータ（`currentUser.json`, `teachers.json`）を用いた表示ロジックを追加
- 詳細`Drawer（DetailDrawer` コンポーネントを新規実装し、各教師の詳細情報を表示可能に
- 科目・曜日の日本語変換定数（`subjectTranslations`, `dayOfWeekTranslations`）と対応フックを追加
- カラムカスタマイズ時の日本語ラベル対応
- `@radix-ui/react-scroll-area` の導入と`ScrollArea`コンポーネント追加

## スクリーンショット

### 講師一覧画面
<img width="2559" height="1265" alt="スクリーンショット 2025-08-07 221529" src="https://github.com/user-attachments/assets/a9f7ae11-9699-4561-b9fe-fbca11710306" />

### 講師の名前をクリックすると詳細情報を表示する

<img width="2554" height="1265" alt="スクリーンショット 2025-08-07 221544" src="https://github.com/user-attachments/assets/530bf869-f50b-43d9-9a1b-57616ec0603a" />

## 動作確認手順

<!-- レビュアーが確認しやすいように、操作手順を具体的に記載してください -->

1. `/teachers` ページにアクセス
2. 教師一覧がテーブル形式で表示されることを確認
3. 名前をクリックすると詳細`Drawer`が開き、担当科目・生徒・勤務可能日などが日本語で表示されることを確認
4. カラム表示カスタマイズで日本語ラベルが表示されることを確認
## 影響範囲

<!-- この変更が影響する画面・機能・ファイルなどを記載してください（例：todo一覧画面、Userモデルなど） -->
- 教師管理画面（`TeachersPage`）
- 教師一覧テーブル（`DataTable` ,`Columns`, `DetailDrawer`）
- 共通定数（`subjectTranslations`, `dayOfWeekTranslations`）
- UIコンポーネント（`ScrollArea`）

## レビューポイント

<!-- レビュアーに特に見てほしい点があればチェックを入れてください -->

- [x] **機能**：仕様どおりに動作するか
- [x] **コード品質**：可読性・保守性
- [x] **セキュリティ**：権限・バリデーション・入力チェック
- [x] **パフォーマンス**：処理速度やリソース使用量
- [ ] **CI**：GitHub Actions のワークフローが成功しているか

## デプロイ／運用

<!-- 該当する項目にチェックを入れて、必要に応じて補足してください -->

- **マイグレーション**：無
- **環境変数の追加**：無
- **破壊的変更の有無**：無

## チェックリスト（作成者用）

<!-- PR作成前に確認した内容にチェックを入れてください -->

- [x] 自身で動作確認・コードレビューを完了した
- [x] 不要なコメント・デバッグコードを削除した
- [x] コミットメッセージがわかりやすく記述されている
- [x] 関連 Issue がリンクされている（あれば）

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか
