### PR TITLE
teacher の値をZustand store に移行、テストの調整

### DIFF
--- a/src/features/teachers/components/Table/Columns.tsx
+++ b/src/features/teachers/components/Table/Columns.tsx
@@ -31,115 +31,119 @@ export const schema = z.object({
 });
 
 // columns を関数として定義し、getDetailDrawerData を受け取る
-export const createColumns = (): ColumnDef<z.infer<typeof schema>>[] => [
-  {
-    id: 'select',
-    header: ({ table }) => (
-      <div className="flex items-center justify-center px-4">
-        <Checkbox
-          checked={
-            table.getIsAllPageRowsSelected() ||
-            (table.getIsSomePageRowsSelected() && 'indeterminate')
-          }
-          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-          aria-label="Select all"
-        />
-      </div>
-    ),
-    cell: ({ row }) => (
-      <div className="flex items-center justify-center">
-        <Checkbox
-          checked={row.getIsSelected()}
-          onCheckedChange={(value) => row.toggleSelected(!!value)}
-          aria-label="Select row"
-        />
-      </div>
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  },
-  {
-    accessorKey: 'name',
-    header: '名前',
-    cell: ({ row }) => {
-      const getTeacherData = useTeachersStore((state) => state.getTeacherData);
-      const detailData = getTeacherData(row.original.id);
-      return detailData ? (
-        <DetailDrawer item={detailData} />
-      ) : (
-        <span>{row.original.name}</span>
-      );
+export const createColumns = (): ColumnDef<z.infer<typeof schema>>[] => {
+  const getTeacherData = useTeachersStore((state) => state.getTeacherData);
+  return [
+    {
+      id: 'select',
+      header: ({ table }) => (
+        <div className="flex items-center justify-center px-4">
+          <Checkbox
+            checked={
+              table.getIsAllPageRowsSelected() ||
+              (table.getIsSomePageRowsSelected() && 'indeterminate')
+            }
+            onCheckedChange={(value) =>
+              table.toggleAllPageRowsSelected(!!value)
+            }
+            aria-label="Select all"
+          />
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="flex items-center justify-center">
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => row.toggleSelected(!!value)}
+            aria-label="Select row"
+          />
+        </div>
+      ),
+      enableSorting: false,
+      enableHiding: false,
     },
-    enableHiding: false,
-  },
-  {
-    accessorKey: 'role',
-    header: '役割',
-    cell: ({ row }) => (
-      <div className="w-32">
-        <Badge variant="outline" className="text-muted-foreground px-1.5">
-          {row.original.role === 'admin' ? (
-            <IconShieldStar className="fill-blue-500" />
-          ) : (
-            <IconUsers className="fill-green-600" />
-          )}
-          {row.original.role}
-        </Badge>
-      </div>
-    ),
-  },
-  {
-    accessorKey: 'employment_status',
-    header: '出勤状況',
-    cell: ({ row }) => (
-      <Badge variant="outline" className="text-muted-foreground px-1.5">
-        {/** Employment Status で分岐する */}
-        {row.original.employment_status === 'active' ? (
-          <IconCircleCheckFilled className="fill-green-500 dark:fill-green-400" />
+    {
+      accessorKey: 'name',
+      header: '名前',
+      cell: ({ row }) => {
+        const detailData = getTeacherData(row.original.id);
+        return detailData ? (
+          <DetailDrawer item={detailData} />
         ) : (
-          <IconLoader />
-        )}
-        {row.original.employment_status}
-      </Badge>
-    ),
-  },
-  {
-    accessorKey: 'classSubject',
-    header: '担当科目',
-    cell: ({ row }) => {
-      const { createIconTranslationBadge } = useSubjectTranslation();
-      const subjects = row.original.classSubject.map((cs) => (
-        <span key={cs.id}>{createIconTranslationBadge(cs.name)}</span>
-      ));
-      return subjects;
+          <span>{row.original.name}</span>
+        );
+      },
+      enableHiding: false,
     },
-  },
-  {
-    accessorKey: 'studentsCount',
-    header: '生徒数',
-    cell: ({ row }) => (
-      <Badge variant="outline" className="px-2">
-        {row.original.studentsCount} 名
-      </Badge>
-    ),
-  },
-  {
-    accessorKey: 'current_sign_in_at',
-    header: '直近ログイン',
-    cell: ({ row }) => {
-      const { label, colorClass, Icon } = useSignInStatus(
-        row.original.current_sign_in_at
-      );
-      return (
-        <Badge variant="outline" className={`px-2 ${colorClass}`}>
-          <Icon />
-          {label}
+    {
+      accessorKey: 'role',
+      header: '役割',
+      cell: ({ row }) => (
+        <div className="w-32">
+          <Badge variant="outline" className="text-muted-foreground px-1.5">
+            {row.original.role === 'admin' ? (
+              <IconShieldStar className="fill-blue-500" />
+            ) : (
+              <IconUsers className="fill-green-600" />
+            )}
+            {row.original.role}
+          </Badge>
+        </div>
+      ),
+    },
+    {
+      accessorKey: 'employment_status',
+      header: '出勤状況',
+      cell: ({ row }) => (
+        <Badge variant="outline" className="text-muted-foreground px-1.5">
+          {/** Employment Status で分岐する */}
+          {row.original.employment_status === 'active' ? (
+            <IconCircleCheckFilled className="fill-green-500 dark:fill-green-400" />
+          ) : (
+            <IconLoader />
+          )}
+          {row.original.employment_status}
         </Badge>
-      );
+      ),
     },
-  },
-  {
-    id: 'actions',
-    cell: ({ row }) => <RawActions teacherId={row.original.id} />,
-  },
-];
+    {
+      accessorKey: 'classSubject',
+      header: '担当科目',
+      cell: ({ row }) => {
+        const { createIconTranslationBadge } = useSubjectTranslation();
+        const subjects = row.original.classSubject.map((cs) => (
+          <span key={cs.id}>{createIconTranslationBadge(cs.name)}</span>
+        ));
+        return subjects;
+      },
+    },
+    {
+      accessorKey: 'studentsCount',
+      header: '生徒数',
+      cell: ({ row }) => (
+        <Badge variant="outline" className="px-2">
+          {row.original.studentsCount} 名
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: 'current_sign_in_at',
+      header: '直近ログイン',
+      cell: ({ row }) => {
+        const { label, colorClass, Icon } = useSignInStatus(
+          row.original.current_sign_in_at
+        );
+        return (
+          <Badge variant="outline" className={`px-2 ${colorClass}`}>
+            <Icon />
+            {label}
+          </Badge>
+        );
+      },
+    },
+    {
+      id: 'actions',
+      cell: ({ row }) => <RawActions teacherId={row.original.id} />,
+    },
+  ];
+};

--- a/src/features/teachers/components/Table/Columns.tsx
+++ b/src/features/teachers/components/Table/Columns.tsx
@@ -13,7 +13,7 @@ import { DetailDrawer } from './DetailDrawer';
 import { useSubjectTranslation } from '@/hooks/useSubjectTranslation';
 import { useSignInStatus } from '@/hooks/useSignInStatus';
 import { RawActions } from './RawActions';
-import type { teacherDetailDrawer } from '../../types/teachers';
+import { useTeachersStore } from '@/stores/teachersStore';
 
 export const schema = z.object({
   id: z.number(),
@@ -31,10 +31,7 @@ export const schema = z.object({
 });
 
 // columns を関数として定義し、getDetailDrawerData を受け取る
-export const createColumns = (
-  getDetailDrawerData: (id: number) => teacherDetailDrawer | undefined,
-  refetch: () => Promise<void>
-): ColumnDef<z.infer<typeof schema>>[] => [
+export const createColumns = (): ColumnDef<z.infer<typeof schema>>[] => [
   {
     id: 'select',
     header: ({ table }) => (
@@ -65,7 +62,8 @@ export const createColumns = (
     accessorKey: 'name',
     header: '名前',
     cell: ({ row }) => {
-      const detailData = getDetailDrawerData(row.original.id);
+      const getTeacherData = useTeachersStore((state) => state.getTeacherData);
+      const detailData = getTeacherData(row.original.id);
       return detailData ? (
         <DetailDrawer item={detailData} />
       ) : (
@@ -142,13 +140,6 @@ export const createColumns = (
   },
   {
     id: 'actions',
-    cell: ({ row }) => (
-      <RawActions
-        teacherId={row.original.id}
-        teacherName={row.original.name}
-        teacherRole={row.original.role}
-        refetch={refetch}
-      />
-    ),
+    cell: ({ row }) => <RawActions teacherId={row.original.id} />,
   },
 ];

--- a/src/features/teachers/components/Table/DataTable.tsx
+++ b/src/features/teachers/components/Table/DataTable.tsx
@@ -47,22 +47,16 @@ import {
   TableRow,
 } from '@/components/ui/display/Table/table';
 import { Tabs, TabsContent } from '@/components/ui/navigation/Tabs/tabs';
-
 import { schema, createColumns } from './Columns';
-
 import { CreateDialog } from './CreateDialog';
-import type { teacherDetailDrawer } from '../../types/teachers';
+import { useTeachersStore } from '@/stores/teachersStore';
 
 // props に getDetailDrawerData を追加
-export const DataTable = ({
-  data: initialData,
-  getDetailDrawerData,
-  refetch,
-}: {
-  data: z.infer<typeof schema>[];
-  getDetailDrawerData: (id: number) => teacherDetailDrawer | undefined;
-  refetch: () => Promise<void>;
-}) => {
+export const DataTable = () => {
+  // Zustand ストアから状態を取得
+  const dataTable: z.infer<typeof schema>[] = useTeachersStore(
+    (state) => state.dataTable
+  );
   const [rowSelection, setRowSelection] = useState({});
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -73,13 +67,10 @@ export const DataTable = ({
   });
 
   // getDetailDrawerData をcreateColumnsに渡すためにuseMemoを使用
-  const columns = useMemo(
-    () => createColumns(getDetailDrawerData, refetch),
-    [getDetailDrawerData, refetch]
-  );
+  const columns = useMemo(() => createColumns(), []);
 
   const table = useReactTable({
-    data: initialData,
+    data: dataTable,
     columns,
     state: {
       sorting,

--- a/src/features/teachers/components/Table/DeleteTeacherDialog.tsx
+++ b/src/features/teachers/components/Table/DeleteTeacherDialog.tsx
@@ -83,7 +83,9 @@ export const DeleteTeacherDialog = ({
             </div>
 
             <DialogDescription asChild>
-              {!loading && !error && (
+              {loading ? (
+                <span className="sr-only">削除確認ダイアログの読み込み中</span>
+              ) : (
                 <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
                   <ul className="list-disc bg-red-50 pl-5 mt-2 space-y-1 text-left">
                     <li>この操作は取り消せません。</li>
@@ -113,7 +115,7 @@ export const DeleteTeacherDialog = ({
                 <Label htmlFor="confirmTeacherName">確認入力</Label>
                 <Input
                   id="confirmTeacherName"
-                  placeholder={teacher?.name || '講師名を入力'}
+                  placeholder={teacher?.name}
                   value={confirmText}
                   onChange={(e) => setConfirmText(e.currentTarget.value)}
                 />

--- a/src/features/teachers/components/Table/RawActions.test.tsx
+++ b/src/features/teachers/components/Table/RawActions.test.tsx
@@ -1,14 +1,13 @@
 import { render, screen } from '@testing-library/react';
-import { expect, vi } from 'vitest';
+import { beforeEach, expect, vi } from 'vitest';
 import { describe, test } from 'vitest';
 import { RawActions } from './RawActions';
 import userEvent from '@testing-library/user-event';
+import { useTeachersStore } from '@/stores/teachersStore';
+import { teacher1 } from '../../fixtures/teachers';
 
 type Props = {
   teacherId: number;
-  teacherName: string;
-  teacherRole: string;
-  refetch: () => Promise<void>;
 };
 
 describe('RawActions', () => {
@@ -16,16 +15,26 @@ describe('RawActions', () => {
     return render(<RawActions {...props} />);
   };
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   test('renders correctly', async () => {
     const user = userEvent.setup();
+    const getTeacherDataMock = vi.spyOn(
+      useTeachersStore.getState(),
+      'getTeacherData'
+    );
+    useTeachersStore.setState({
+      detailDrawer: [teacher1],
+    });
     const mockProps: Props = {
-      teacherId: 1,
-      teacherName: 'John Doe',
-      teacherRole: 'teacher',
-      refetch: vi.fn(),
+      teacherId: 2,
     };
 
     renderComponent(mockProps);
+
+    expect(getTeacherDataMock).toHaveBeenCalledWith(mockProps.teacherId);
 
     // 3点メニューをクリック
     const menuButton = screen.getByRole('button', { name: /open menu/i });
@@ -39,18 +48,26 @@ describe('RawActions', () => {
     // ダイアログが開いていることを確認
     const dialog = screen.getByRole('dialog');
     expect(dialog).toBeInTheDocument();
-    expect(dialog).toHaveTextContent('John Doe');
+    expect(dialog).toHaveTextContent(teacher1.name);
   });
   test('does not show delete option for admin role', async () => {
+    const getTeacherDataMock = vi.spyOn(
+      useTeachersStore.getState(),
+      'getTeacherData'
+    );
+    teacher1.role = 'admin'; // admin roleを設定
+    useTeachersStore.setState({
+      detailDrawer: [teacher1],
+    });
+
     const user = userEvent.setup();
     const mockProps: Props = {
-      teacherId: 1,
-      teacherName: 'Jane Doe',
-      teacherRole: 'admin',
-      refetch: vi.fn(),
+      teacherId: 2,
     };
 
     renderComponent(mockProps);
+
+    expect(getTeacherDataMock).toHaveBeenCalledWith(mockProps.teacherId);
 
     // 3点メニューをクリック
     const menuButton = screen.getByRole('button', { name: /open menu/i });

--- a/src/features/teachers/components/Table/RawActions.tsx
+++ b/src/features/teachers/components/Table/RawActions.tsx
@@ -9,21 +9,16 @@ import {
 import { IconDotsVertical } from '@tabler/icons-react';
 import { useState } from 'react';
 import { DeleteTeacherDialog } from './DeleteTeacherDialog';
+import { useTeachersStore } from '@/stores/teachersStore';
 
 type Props = {
   teacherId: number;
-  teacherName: string;
-  teacherRole: string;
-  refetch: () => Promise<void>;
 };
 
-export const RawActions = ({
-  teacherId,
-  teacherName,
-  teacherRole,
-  refetch,
-}: Props) => {
+export const RawActions = ({ teacherId }: Props) => {
   const [open, setOpen] = useState(false);
+  const getTeacherData = useTeachersStore((state) => state.getTeacherData);
+  const teacher = getTeacherData(teacherId);
   return (
     <>
       <DropdownMenu>
@@ -39,7 +34,7 @@ export const RawActions = ({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-32">
           <DropdownMenuItem>編集</DropdownMenuItem>
-          {teacherRole !== 'admin' && (
+          {teacher?.role !== 'admin' && (
             <>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -59,8 +54,6 @@ export const RawActions = ({
         open={open}
         onOpenChange={setOpen}
         teacherId={teacherId}
-        teacherName={teacherName}
-        refetch={refetch}
       />
     </>
   );

--- a/src/features/teachers/fixtures/teachers.ts
+++ b/src/features/teachers/fixtures/teachers.ts
@@ -1,8 +1,5 @@
-import {
-  toTeacherDetailDrawer,
-  type teacherDetailDrawer,
-} from '../hooks/Table/useFomatTeachersData';
-import type { currentUser } from '../types/teachers';
+import { toTeacherDetailDrawer } from '../hooks/Table/useFomatTeachersData';
+import type { currentUser, teacherDetailDrawer } from '../types/teachers';
 
 // useFormatTeachersData.test のデータ
 export const currentUserResponse = {

--- a/src/features/teachers/hooks/Table/useFetchTeachers.ts
+++ b/src/features/teachers/hooks/Table/useFetchTeachers.ts
@@ -13,7 +13,7 @@ export const useFetchTeachers = () => {
   const [currentUserData, setCurrentUserData] = useState<currentUser | null>(
     null
   );
-  const [teachersData, setTeachersData] = useState<teachers | null>(null);
+  const [teachersData, setTeachersData] = useState<teachers>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true); // ローディング状態を追加
   const fetchTeachersData = useCallback(async () => {

--- a/src/features/teachers/hooks/Table/useFomatTeachersData.ts
+++ b/src/features/teachers/hooks/Table/useFomatTeachersData.ts
@@ -83,5 +83,5 @@ export const useFormatTeachersData = (
   useEffect(() => {
     setDataTable(dataTable);
     setDetailDrawer(detailDrawer);
-  }, [dataTable, detailDrawer]);
+  }, [dataTable, detailDrawer, setDataTable, setDetailDrawer]);
 };

--- a/src/features/teachers/hooks/Table/useFomatTeachersData.ts
+++ b/src/features/teachers/hooks/Table/useFomatTeachersData.ts
@@ -1,8 +1,10 @@
+import { useEffect } from 'react';
 import type {
   currentUser,
   teacherDataTable,
   teacherDetailDrawer,
 } from '../../types/teachers';
+import { useTeachersStore } from '@/stores/teachersStore';
 
 // toTeacherRow や toTeacherDetailDrawer に渡すデータの型(currentUser や teachers)
 type fetchData = currentUser;
@@ -58,9 +60,11 @@ export const toTeacherDetailDrawer = (
 
 // パラメータとして currentUserData と teachersData を受け取るように変更
 export const useFormatTeachersData = (
-  currentUserData?: currentUser | null,
-  teachersData?: currentUser[] | null
+  currentUserData: currentUser | null,
+  teachersData: currentUser[] | null
 ) => {
+  const setDataTable = useTeachersStore((state) => state.setDataTable);
+  const setDetailDrawer = useTeachersStore((state) => state.setDetailDrawer);
   // teachersData に null 要素が混ざる可能性もケアして filter(Boolean)
   const teacherRows = (teachersData ?? []).filter(Boolean).map(toTeacherRow);
   const detailRows = (teachersData ?? [])
@@ -76,10 +80,8 @@ export const useFormatTeachersData = (
     ? [toTeacherDetailDrawer(currentUserData), ...detailRows]
     : detailRows;
 
-  // ID でdetailDrawer のデータを検索する関数を追加
-  const getDetailDrawerData = (id: number): teacherDetailDrawer | undefined => {
-    return detailDrawer.find((item) => item.id === id);
-  };
-
-  return { dataTable, getDetailDrawerData };
+  useEffect(() => {
+    setDataTable(dataTable);
+    setDetailDrawer(detailDrawer);
+  }, [dataTable, detailDrawer]);
 };

--- a/src/features/teachers/types/teachers.ts
+++ b/src/features/teachers/types/teachers.ts
@@ -44,11 +44,11 @@ export type currentUser = {
   available_days: AvailableDays[] | [];
 };
 
-export type teachers = currentUser[] | [];
+export type teachers = currentUser[] | null;
 
 export type fetchTeachersSuccessResponse = {
   current_user: currentUser | null;
-  teachers: teachers | null;
+  teachers: teachers;
 };
 
 export type fetchTeachersErrorResponse = {

--- a/src/pages/teachers/TeachersPage.tsx
+++ b/src/pages/teachers/TeachersPage.tsx
@@ -4,12 +4,8 @@ import { useFetchTeachers } from '@/features/teachers/hooks/Table/useFetchTeache
 import { useFormatTeachersData } from '@/features/teachers/hooks/Table/useFomatTeachersData';
 
 export const TeachersPage = () => {
-  const { loading, error, refetch, currentUserData, teachersData } =
-    useFetchTeachers();
-  const { dataTable, getDetailDrawerData } = useFormatTeachersData(
-    currentUserData,
-    teachersData
-  );
+  const { loading, error, currentUserData, teachersData } = useFetchTeachers();
+  useFormatTeachersData(currentUserData, teachersData);
 
   if (loading) {
     return (
@@ -24,11 +20,7 @@ export const TeachersPage = () => {
   return (
     <div className="p-6">
       {error && <div className="text-red-500 mb-4">{error}</div>}
-      <DataTable
-        data={dataTable}
-        getDetailDrawerData={getDetailDrawerData}
-        refetch={refetch}
-      />
+      <DataTable />
     </div>
   );
 };

--- a/src/stores/teachersStore.ts
+++ b/src/stores/teachersStore.ts
@@ -1,0 +1,34 @@
+import type {
+  teacherDataTable,
+  teacherDetailDrawer,
+} from '@/features/teachers/types/teachers';
+import { create } from 'zustand';
+
+type Teachers = {
+  dataTable: teacherDataTable[];
+  detailDrawer: teacherDetailDrawer[];
+  setDataTable: (data: teacherDataTable[]) => void;
+  setDetailDrawer: (data: teacherDetailDrawer[]) => void;
+  getTeacherData: (id: number) => teacherDetailDrawer | undefined;
+  deleteTeacherLocal: (id: number) => void;
+};
+
+export const useTeachersStore = create<Teachers>((set, get) => ({
+  dataTable: [],
+  detailDrawer: [],
+  setDataTable: (data) => {
+    set({ dataTable: data });
+  },
+  setDetailDrawer: (data) => {
+    set({ detailDrawer: data });
+  },
+  getTeacherData: (id: number) => {
+    return get().detailDrawer.find((teacher) => teacher.id === id);
+  },
+  deleteTeacherLocal: (id: number) => {
+    set((state) => ({
+      detailDrawer: state.detailDrawer.filter((teacher) => teacher.id !== id),
+      dataTable: state.dataTable.filter((teacher) => teacher.id !== id),
+    }));
+  },
+}));


### PR DESCRIPTION
## ISSUE

close #91 

## 実装概要

<!-- この PR の目的・背景を 1～2 行で記載してください（例：バグ修正、UI改善、パフォーマンス向上など） -->
### Zustand ストアへの移行

- teachersStore を新規作成し、dataTable と detailDrawer の状態管理を集約
- getTeacherData 関数を追加し、特定の講師データを取得可能に
- deleteTeacherLocal 関数を追加し、ローカルでの即時削除を実現
### コンポーネントのリファクタリング

- DataTable コンポーネントを Zustand ストアに対応させ、props を削減
- Columns コンポーネントで Zustand ストアを使用し、getDetailDrawerData の依存を排除
- DeleteTeacherDialog で Zustand ストアを使用し、削除後のローカル更新を実現
### テストの更新

- DeleteTeacherDialog.test.tsx を更新し、deleteTeacherLocal の呼び出しを検証
- RawActions.test.tsx を更新し、getTeacherData の動作を確認
- useFormatTeachersData.test.ts を更新し、Zustand ストアの状態を検証
### その他の変更

- useFormatTeachersData を Zustand ストアに対応させ、状態を直接更新するよう変更
- TeachersPage をリファクタリングし、DataTable の props を削減

## スクリーンショット

<!-- 変更前後のスクリーンショットやGIFを貼ってください。なければ省略可能です -->

## 動作確認手順

<!-- レビュアーが確認しやすいように、操作手順を具体的に記載してください -->

1. /teachers ページにアクセス
2. 各講師行の3点メニューをクリック
3. 管理者以外の講師で「削除」オプションが表示されることを確認
4. 「削除」をクリックし、削除確認ダイアログが開くことを確認
5. 講師名を正確に入力して「講師を削除する」ボタンをクリック
6. 削除成功の通知が表示され、リストから講師が削除されることを確認
7. 管理者の行では削除オプションが表示されないことを確認

## 影響範囲

<!-- この変更が影響する画面・機能・ファイルなどを記載してください（例：todo一覧画面、Userモデルなど） -->
- 講師管理機能全般（TeachersPage, DataTable, Columns, RawActions, DeleteTeacherDialog）
- データフェッチング（useFetchTeachers, useFormatTeachersData）
- 新規削除機能（teachersStore）

## レビューポイント

<!-- レビュアーに特に見てほしい点があればチェックを入れてください -->

- Zustand 移行後も問題なく削除ができるか
- CIが成功するか

## デプロイ／運用

<!-- 該当する項目にチェックを入れて、必要に応じて補足してください -->

- **マイグレーション**：無
- **環境変数の追加**：無
- **破壊的変更の有無**：無

## チェックリスト（作成者用）

<!-- PR作成前に確認した内容にチェックを入れてください -->

- [ ] 自身で動作確認・コードレビューを完了した
- [ ] 不要なコメント・デバッグコードを削除した
- [ ] コミットメッセージがわかりやすく記述されている
- [ ] 関連 Issue がリンクされている（あれば）

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか
