### PR TITLE
学年ごとに分類するテーブルを作成

### DIFF
--- a/src/Router/ProtectedArea.tsx
+++ b/src/Router/ProtectedArea.tsx
@@ -19,32 +19,40 @@ export const ProtectedArea = () => {
     <>
       {/* 背景・通常用のルーティング */}
       <Routes location={background || location}>
-        {/** admin, teacher 共通 */}
+        {/** 管理画面：admin, teacher 共通のレイアウト */}
         <Route element={<RoleRoute allowedRoles={['admin', 'teacher']} />}>
           <Route element={<ManagementDashboard />}>
+            {/* admin, teacher 共通 */}
             <Route path="/students" element={<StudentsPage />} />
+
+            {/* admin 専用：NestedRoute で権限チェック */}
+            <Route element={<RoleRoute allowedRoles={['admin']} />}>
+              <Route path="/teachers" element={<TeachersPage />} />
+              {/* 直アクセス時のみ表示 */}
+              {!background && (
+                <Route
+                  path="/teachers/:id/edit"
+                  element={<EditTeacherDialog />}
+                />
+              )}
+            </Route>
           </Route>
-          {/** 生徒ごとのページ */}
+        </Route>
+
+        {/** 生徒ごとのページ（別レイアウト） */}
+        <Route element={<RoleRoute allowedRoles={['admin', 'teacher']} />}>
           <Route element={<StudentDashboard />}>
             <Route path="/dashboard/:id" element={<DashboardPage />} />
           </Route>
         </Route>
 
-        {/** admin 専用 */}
-        <Route element={<RoleRoute allowedRoles={['admin']} />}>
-          <Route element={<ManagementDashboard />}>
-            <Route path="/teachers" element={<TeachersPage />} />
-            {/* 直アクセス時に表示されるフルページ版の編集 エラーハンドリングを行う */}
-            <Route path="/teachers/:id/edit" element={<EditTeacherDialog />} />
-          </Route>
-        </Route>
         {/** エラー表示画面 */}
         <Route path="/forbidden" element={<ForbiddenPage />} />
-        <Route path="*" element={<NotFoundPage />} />
         <Route
           path="/internal_server_error"
           element={<InternalServerErrorPage />}
         />
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
 
       {/* モーダル用：背景がある時だけ重ねる */}
@@ -53,13 +61,6 @@ export const ProtectedArea = () => {
           <Route element={<RoleRoute allowedRoles={['admin']} />}>
             <Route path="/teachers/:id/edit" element={<EditTeacherDialog />} />
           </Route>
-          {/** エラー表示画面 */}
-          <Route path="/forbidden" element={<ForbiddenPage />} />
-          <Route path="*" element={<NotFoundPage />} />
-          <Route
-            path="/internal_server_error"
-            element={<InternalServerErrorPage />}
-          />
         </Routes>
       )}
     </>

--- a/src/constants/studentsLevel.ts
+++ b/src/constants/studentsLevel.ts
@@ -1,0 +1,18 @@
+// 小1〜高3の作成
+export const STUDENTS_LEVEL_OPTIONS = [
+  ...Array.from({ length: 6 }, (_, i) => ({
+    school_stage: 'elementary_school',
+    grade: i + 1,
+    label: `小学${i + 1}年`,
+  })),
+  ...Array.from({ length: 3 }, (_, i) => ({
+    school_stage: 'junior_high_school',
+    grade: i + 1,
+    label: `中学${i + 1}年`,
+  })),
+  ...Array.from({ length: 3 }, (_, i) => ({
+    school_stage: 'high_school',
+    grade: i + 1,
+    label: `高校${i + 1}年`,
+  })),
+] as const;

--- a/src/features/students/components/table/StudentsTable.tsx
+++ b/src/features/students/components/table/StudentsTable.tsx
@@ -22,7 +22,7 @@ import type {
   SortingState,
   VisibilityState,
 } from '@tanstack/react-table';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/form/Button/button';
 import {
   DropdownMenu,
@@ -49,9 +49,17 @@ import {
 import { Tabs, TabsContent } from '@/components/ui/navigation/Tabs/tabs';
 import { StudentsColumns } from './StudentsColumns';
 import { useStudentsStore } from '@/stores/studentsStore';
-import { useStudentsQuery } from '../../queries/useStudentsQuery';
+import { STUDENTS_LEVEL_OPTIONS } from '@/constants/studentsLevel';
+import z from 'zod';
+import { metaSchema, studentSchema } from '../../types/students';
 
-export const StudentsTable = () => {
+export const StudentsTable = ({
+  data,
+  meta,
+}: {
+  data: z.infer<typeof studentSchema>[];
+  meta: z.infer<typeof metaSchema>;
+}) => {
   const [rowSelection, setRowSelection] = useState({});
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -62,17 +70,55 @@ export const StudentsTable = () => {
   });
   const filters = useStudentsStore((state) => state.filters);
   const setFilters = useStudentsStore((state) => state.setFilters);
-  const { data } = useStudentsQuery(filters);
 
   const columns = StudentsColumns();
   const pageCount =
-    data?.meta?.total_pages ??
-    (data?.meta?.total_count
-      ? Math.ceil(data.meta.total_count / (filters.perPage ?? 10))
+    meta?.total_pages ??
+    (meta?.total_count
+      ? Math.ceil(meta.total_count / (filters.perPage ?? 10))
       : 1);
+  const VIEW_VALUE = 'students-table-view';
+  const selectValue = (() => {
+    if (!filters.school_stage || !filters.grade) return 'all';
+    return `${filters.school_stage}-${filters.grade}`;
+  })();
+
+  const onSelectChange = (value: string) => {
+    if (value === 'all') {
+      setFilters({
+        ...filters,
+        school_stage: undefined,
+        grade: undefined,
+        page: 1,
+      });
+      table.setPageIndex(0);
+      return;
+    }
+
+    const [school_stage, gradeString] = value.split('-');
+    const grade = Number(gradeString);
+
+    const newFilters = {
+      ...filters,
+      school_stage,
+      grade,
+      page: 1,
+    };
+    setFilters(newFilters);
+    table.setPageIndex(0);
+  };
+
+  // setFilters の更新は 描画後に行う
+  useEffect(() => {
+    setFilters((prev) => ({
+      ...prev,
+      page: pagination.pageIndex + 1,
+      perPage: pagination.pageSize,
+    }));
+  }, [pagination.pageIndex, pagination.pageSize, setFilters]);
 
   const table = useReactTable({
-    data: data?.students ?? [],
+    data: data,
     columns,
     state: {
       sorting,
@@ -90,14 +136,9 @@ export const StudentsTable = () => {
     onColumnFiltersChange: setColumnFilters,
     onColumnVisibilityChange: setColumnVisibility,
     onPaginationChange: (updater) => {
-      const next =
-        typeof updater === 'function' ? updater(pagination) : updater;
-      setPagination(next); // ローカル state 更新
-      setFilters({
-        ...filters,
-        page: next.pageIndex + 1,
-        perPage: next.pageSize,
-      });
+      setPagination((prev) =>
+        typeof updater === 'function' ? updater(prev) : updater
+      );
     },
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
@@ -119,15 +160,13 @@ export const StudentsTable = () => {
 
   return (
     <Tabs
-      defaultValue="outline"
+      defaultValue={VIEW_VALUE}
       className="w-full flex-col justify-start gap-6"
     >
       <div className="flex items-center justify-between px-4 lg:px-6">
-        <Label htmlFor="view-selector" className="sr-only">
-          View
-        </Label>
         {/** セレクター */}
-        <Select defaultValue="outline">
+        <Select value={selectValue} onValueChange={onSelectChange}>
+          {/* ↑ selectValue() ではなく selectValue */}
           <SelectTrigger
             className="flex w-fit @4xl/main:hidden"
             size="sm"
@@ -136,7 +175,15 @@ export const StudentsTable = () => {
             <SelectValue placeholder="Select a view" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="outline">生徒一覧</SelectItem>
+            <SelectItem value="all">生徒一覧</SelectItem>
+            {STUDENTS_LEVEL_OPTIONS.map((option) => (
+              <SelectItem
+                key={option.label}
+                value={`${option.school_stage}-${option.grade}`}
+              >
+                {option.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
 
@@ -186,7 +233,7 @@ export const StudentsTable = () => {
         {/** タブの内容 */}
       </div>
       <TabsContent
-        value="outline"
+        value={VIEW_VALUE}
         className="relative flex flex-col gap-4 overflow-auto px-4 lg:px-6"
       >
         <div className="overflow-hidden rounded-lg border">
@@ -232,7 +279,7 @@ export const StudentsTable = () => {
                     colSpan={columns.length}
                     className="h-24 text-center"
                   >
-                    No results.
+                    生徒が見つかりません。
                   </TableCell>
                 </TableRow>
               )}

--- a/src/features/students/components/table/StudentsTable.tsx
+++ b/src/features/students/components/table/StudentsTable.tsx
@@ -84,31 +84,29 @@ export const StudentsTable = ({
   })();
 
   const onSelectChange = (value: string) => {
+    let newFilters;
     if (value === 'all') {
-      setFilters({
+      newFilters = {
         ...filters,
         school_stage: undefined,
         grade: undefined,
         page: 1,
-      });
-      table.setPageIndex(0);
-      return;
+      };
+    } else {
+      const [school_stage, gradeString] = value.split('-');
+      const grade = Number(gradeString);
+      newFilters = {
+        ...filters,
+        school_stage,
+        grade,
+        page: 1,
+      };
     }
-
-    const [school_stage, gradeString] = value.split('-');
-    const grade = Number(gradeString);
-
-    const newFilters = {
-      ...filters,
-      school_stage,
-      grade,
-      page: 1,
-    };
     setFilters(newFilters);
     table.setPageIndex(0);
   };
 
-  // setFilters の更新は 描画後に行う
+  // setFiltersは描画後に更新する
   useEffect(() => {
     setFilters((prev) => ({
       ...prev,
@@ -166,7 +164,6 @@ export const StudentsTable = ({
       <div className="flex items-center justify-between px-4 lg:px-6">
         {/** セレクター */}
         <Select value={selectValue} onValueChange={onSelectChange}>
-          {/* ↑ selectValue() ではなく selectValue */}
           <SelectTrigger
             className="flex w-fit @4xl/main:hidden"
             size="sm"

--- a/src/pages/students/StudentsPage.tsx
+++ b/src/pages/students/StudentsPage.tsx
@@ -6,7 +6,7 @@ import { useStudentsStore } from '@/stores/studentsStore';
 
 export const StudentsPage = () => {
   const filters = useStudentsStore((state) => state.filters);
-  const { error, isError, isPending } = useStudentsQuery(filters);
+  const { data, error, isError, isPending } = useStudentsQuery(filters);
 
   if (isPending) {
     return (
@@ -23,7 +23,17 @@ export const StudentsPage = () => {
       {isError && (
         <div className="text-red-500 mb-4">{getErrorMessage(error)}</div>
       )}
-      <StudentsTable />
+      <StudentsTable
+        data={data?.students ?? []}
+        meta={
+          data?.meta ?? {
+            total_pages: 0,
+            total_count: 0,
+            current_page: 0,
+            per_page: 0,
+          }
+        }
+      />
     </div>
   );
 };

--- a/src/stores/studentsStore.ts
+++ b/src/stores/studentsStore.ts
@@ -8,18 +8,20 @@ type Filters = {
   perPage: number; // 1ページあたりの件数
 };
 
-type StudentState = {
+type StudentsState = {
   filters: Filters;
-  setFilters: (filters: Partial<Filters>) => void;
+  setFilters: (
+    patch: Partial<Filters> | ((prev: Filters) => Partial<Filters>)
+  ) => void;
 };
 
-export const useStudentsStore = create<StudentState>((set) => ({
-  filters: {
-    page: 1,
-    perPage: 10,
-  },
-  setFilters: (newFilters) =>
+export const useStudentsStore = create<StudentsState>((set) => ({
+  filters: { page: 1, perPage: 10 },
+  setFilters: (patch) =>
     set((state) => ({
-      filters: { ...state.filters, ...newFilters },
+      filters: {
+        ...state.filters,
+        ...(typeof patch === 'function' ? patch(state.filters) : patch),
+      },
     })),
 }));


### PR DESCRIPTION
## ISSUE

close #112 

## 実装概要

- **学年フィルタリング機能の追加**
  - 生徒一覧ページに学年ごとのフィルタリング機能を追加
  - `STUDENTS_LEVEL_OPTIONS` を定義し、小学1年から高校3年までの学年オプションを作成
  - セレクターで学年を選択すると、フィルタリングされた生徒データが表示されるように実装

- **`StudentsTable` のリファクタリング**
  - `StudentsTable` コンポーネントを汎用的に利用できるように `data` と `meta` を props として受け取る形に変更
  - ページネーションやフィルタリングのロジックを整理し、`useStudentsStore` を活用

- **`ProtectedArea` のルーティング整理**
  - `ManagementDashboard` の重複定義を解消し、コードを簡潔化
  - `RoleRoute` をネストして権限チェックを効率化

- **その他の改善**
  - `StudentsPage` でエラーメッセージを表示するロジックを追加
  - `studentsStore` の `setFilters` を関数型のパッチ適用に対応

---

## スクリーンショット

---

## 動作確認手順

1. `/students` ページにアクセス
2. 学年セレクターで「小学1年」を選択
3. 小学1年の生徒のみが表示されることを確認
4. 学年セレクターで「中学2年」を選択
5. 中学2年の生徒のみが表示されることを確認
6. 「生徒一覧」を選択し、すべての生徒が表示されることを確認

---

## 影響範囲

- 生徒一覧ページ
- `StudentsTable` コンポーネント
- `ProtectedArea` のルーティング
- `studentsStore` の状態管理

---

## レビューポイント

- [ ] **機能**：学年フィルタリングが仕様どおりに動作するか
- [ ] **コード品質**：リファクタリング後のコードが可読性・保守性に優れているか
- [ ] **セキュリティ**：権限チェックが適切に行われているか
- [ ] **パフォーマンス**：フィルタリングやページネーションの処理が効率的か
- [ ] **CI**：GitHub Actions のワークフローが成功しているか

---

## デプロイ／運用

- **マイグレーション**：無
- **環境変数の追加**：無
- **破壊的変更の有無**：無

---

## チェックリスト（作成者用）

- [x] 自身で動作確認・コードレビューを完了した
- [x] 不要なコメント・デバッグコードを削除した
- [x] コミットメッセージがわかりやすく記述されている
- [x] 関連 Issue がリンクされている（あれば）

---

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか
