### PR TITLE
teacher 編集をする際にstudent がいたら表示を変える

### DIFF
--- a/src/Router/ProtectedArea.tsx
+++ b/src/Router/ProtectedArea.tsx
@@ -68,8 +68,6 @@ export const ProtectedArea = () => {
         <Routes>
           <Route element={<RoleRoute allowedRoles={["admin"]} />}>
             <Route path="/teachers/:id/edit" element={<EditTeacherDialog />} />
-          </Route>
-          <Route element={<RoleRoute allowedRoles={["admin", "teacher"]} />}>
             <Route path="/students/:id/edit" element={<EditStudentDialog />} />
           </Route>
         </Routes>

--- a/src/features/students/components/dialog/EditStudentDialog.tsx
+++ b/src/features/students/components/dialog/EditStudentDialog.tsx
@@ -31,27 +31,15 @@ export const EditStudentDialog = () => {
   const state = location.state;
   const hasBackground = !!state?.background;
 
-  const { student, isNotFound, isLoading } = useStudentForEdit(
-    studentId,
-    state
-  );
-
-  // ここまでくれば student は確実に存在する
-  const formattedStudent = useMemo(() => {
-    return student ? studentFormatForEdit(student) : undefined;
-  }, [student]);
-
-  const isMobile = useIsMobile();
-  const navigate = useNavigate();
-  const handleClose = () => {
-    navigate(-1);
-  };
-
   // エラーハンドリングによる画面遷移
   if (!hasBackground) {
     return <Navigate to="/students" replace />;
   }
 
+  const { student, isNotFound, isLoading } = useStudentForEdit(
+    studentId,
+    state
+  );
   // student の取得中
   if (isLoading) {
     return (
@@ -65,6 +53,17 @@ export const EditStudentDialog = () => {
   if (isNotFound) {
     return <Navigate to="/404" replace />;
   }
+
+  // ここまでくれば student は確実に存在する
+  const formattedStudent = useMemo(() => {
+    return student ? studentFormatForEdit(student) : undefined;
+  }, [student]);
+
+  const isMobile = useIsMobile();
+  const navigate = useNavigate();
+  const handleClose = () => {
+    navigate(-1);
+  };
 
   const { value, setValue, submit, reset } = useStudentForm(
     "edit",

--- a/src/features/students/components/dialog/EditStudentDialog.tsx
+++ b/src/features/students/components/dialog/EditStudentDialog.tsx
@@ -31,15 +31,26 @@ export const EditStudentDialog = () => {
   const state = location.state;
   const hasBackground = !!state?.background;
 
-  // エラーハンドリングによる画面遷移
-  if (!hasBackground) {
-    return <Navigate to="/students" replace />;
-  }
-
   const { student, isNotFound, isLoading } = useStudentForEdit(
     studentId,
     state
   );
+
+  // ここまでくれば student は確実に存在する
+  const formattedStudent = useMemo(() => {
+    return student ? studentFormatForEdit(student) : undefined;
+  }, [student]);
+
+  const isMobile = useIsMobile();
+  const navigate = useNavigate();
+  const handleClose = () => {
+    navigate(-1);
+  };
+
+  // エラーハンドリングによる画面遷移
+  if (!hasBackground) {
+    return <Navigate to="/students" replace />;
+  }
 
   // student の取得中
   if (isLoading) {
@@ -54,17 +65,6 @@ export const EditStudentDialog = () => {
   if (isNotFound) {
     return <Navigate to="/404" replace />;
   }
-
-  // ここまでくれば student は確実に存在する
-  const formattedStudent = useMemo(() => {
-    return studentFormatForEdit(student!);
-  }, [student]);
-
-  const isMobile = useIsMobile();
-  const navigate = useNavigate();
-  const handleClose = () => {
-    navigate(-1);
-  };
 
   const { value, setValue, submit, reset } = useStudentForm(
     "edit",

--- a/src/features/teachers/components/TeacherForm/TeacherForm.tsx
+++ b/src/features/teachers/components/TeacherForm/TeacherForm.tsx
@@ -6,15 +6,19 @@ import { NameField } from "@/components/common/form/NameField";
 import { StatusSelect } from "@/components/common/form/StatusSelect";
 import { TeachableSubjectCheckboxes } from "./parts/TeachableSubjectCheckboxes";
 import { TeachableDayCheckboxes } from "./parts/TeachableDayCheckboxes";
+import { Link } from "react-router-dom";
 
 export const TeacherForm = ({
   formData,
   setFormData,
   handleClose,
   onSubmit,
+  teacher,
 }: TeacherFormProps) => {
   const H = TeacherFormHandler(setFormData);
   const variant = "TeacherFormData";
+  const students = teacher?.students ?? [];
+
   return (
     <form onSubmit={onSubmit} className="px-4 sm:px-6 py-6 space-y-5">
       <div className="space-y-4">
@@ -30,18 +34,41 @@ export const TeacherForm = ({
           status={formData.employment_status}
           onChange={H.handleSelectEmployment}
         />
+        {/** 指導している生徒がいる場合、先に連携を解除する必要あり */}
+        {students.length > 0 && (
+          <>
+            <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-700">
+              <p className="text-sm text-muted-foreground mb-5">
+                この講師は以下の生徒を指導しています。講師情報を編集する前に、各生徒の編集画面で講師との連携を解除してください。
+              </p>
 
-        {/* 担当科目：複数チェック */}
-        <TeachableSubjectCheckboxes
-          formData={formData}
-          onChange={H.toggleInArray}
-        />
+              <ul className="list-disc bg-yellow-50 pl-5 mt-2 space-y-1 text-left">
+                {students.map((student) => (
+                  <li key={student.id}>{student.name}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="flex justify-center mt-6">
+              <Button variant="secondary" asChild size="sm" className="px-4">
+                <Link to="/students">生徒一覧へ</Link>
+              </Button>
+            </div>
+          </>
+        )}
 
-        {/* 担当可能曜日：複数チェック */}
-        <TeachableDayCheckboxes
-          formData={formData}
-          onChange={H.toggleInArray}
-        />
+        {students.length === 0 && (
+          <>
+            <TeachableSubjectCheckboxes
+              formData={formData}
+              onChange={H.toggleInArray}
+            />
+
+            <TeachableDayCheckboxes
+              formData={formData}
+              onChange={H.toggleInArray}
+            />
+          </>
+        )}
       </div>
 
       <DialogFooter className="mt-6 gap-2 sm:justify-between">

--- a/src/features/teachers/components/TeacherForm/TeacherForm.tsx
+++ b/src/features/teachers/components/TeacherForm/TeacherForm.tsx
@@ -42,7 +42,7 @@ export const TeacherForm = ({
                 この講師は以下の生徒を指導しています。講師情報を編集する前に、各生徒の編集画面で講師との連携を解除してください。
               </p>
 
-              <ul className="list-disc bg-yellow-50 pl-5 mt-2 space-y-1 text-left">
+              <ul className="list-disc pl-5 mt-2 space-y-1 text-left">
                 {students.map((student) => (
                   <li key={student.id}>{student.name}</li>
                 ))}

--- a/src/features/teachers/components/dialogs/EditTeacherDialog.tsx
+++ b/src/features/teachers/components/dialogs/EditTeacherDialog.tsx
@@ -89,6 +89,7 @@ export const EditTeacherDialog = () => {
             setFormData={setFormData}
             handleClose={handleClose}
             onSubmit={handleSubmit}
+            teacher={teacher}
           />
         )}
       </DialogContent>

--- a/src/features/teachers/tests/components/detail/DetailDrawer.test.tsx
+++ b/src/features/teachers/tests/components/detail/DetailDrawer.test.tsx
@@ -34,8 +34,6 @@ describe("DetailDrawer", () => {
       expect(screen.getByText(/月曜日/)).toBeInTheDocument();
       expect(screen.getByText(/水曜日/)).toBeInTheDocument();
       expect(screen.getByText(/金曜日/)).toBeInTheDocument();
-      expect(screen.getByText(/Student One/)).toBeInTheDocument();
-      expect(screen.getByText(/Student Two/)).toBeInTheDocument();
       expect(screen.getByText("john.doe@example.com")).toBeInTheDocument();
       expect(screen.getByText("1か月以上前")).toBeInTheDocument();
     });

--- a/src/features/teachers/tests/hooks/useFormatTeachersData.test.ts
+++ b/src/features/teachers/tests/hooks/useFormatTeachersData.test.ts
@@ -1,15 +1,15 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
-import type { currentUser } from '../../types/teachers';
-import { useFormatTeachersData } from '../../hooks/useFormatTeachersData';
-import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { currentUser } from "../../types/teachers";
+import { useFormatTeachersData } from "../../hooks/useFormatTeachersData";
+import { renderHook } from "@testing-library/react";
 
-import { useTeachersStore } from '@/stores/teachersStore';
+import { useTeachersStore } from "@/stores/teachersStore";
 import {
   currentUserResponse,
   teacher1,
-} from '../../../../tests/fixtures/teachers/teachers';
+} from "../../../../tests/fixtures/teachers/teachers";
 
-describe('useFormatTeachersData', () => {
+describe("useFormatTeachersData", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useTeachersStore.setState({
@@ -18,13 +18,13 @@ describe('useFormatTeachersData', () => {
     });
   });
 
-  const setDataTableSpy = vi.spyOn(useTeachersStore.getState(), 'setDataTable');
+  const setDataTableSpy = vi.spyOn(useTeachersStore.getState(), "setDataTable");
   const setDetailDrawerSpy = vi.spyOn(
     useTeachersStore.getState(),
-    'setDetailDrawer'
+    "setDetailDrawer"
   );
 
-  test('formats teachers data correctly', () => {
+  test("formats teachers data correctly", () => {
     const teachersResponse = [teacher1] as unknown as currentUser[];
     const loading = false;
     renderHook(() =>
@@ -38,57 +38,57 @@ describe('useFormatTeachersData', () => {
     // 先頭: currentUser
     expect(dataTable[0]).toEqual({
       id: 1,
-      name: 'John Doe',
-      role: 'admin',
-      employment_status: 'active',
+      name: "John Doe",
+      role: "admin",
+      employment_status: "active",
       class_subjects: [
-        { id: 1, name: 'english' },
-        { id: 3, name: 'mathematics' },
+        { id: 1, name: "english" },
+        { id: 3, name: "mathematics" },
       ],
-      studentsCount: 2,
-      current_sign_in_at: '2023-01-01T12:00:00Z',
+      studentsCount: 0,
+      current_sign_in_at: "2023-01-01T12:00:00Z",
     });
 
     // 次: teacher1
     expect(dataTable[1]).toEqual({
       id: 2,
-      name: 'Jane Smith',
-      role: 'teacher',
-      employment_status: 'active',
+      name: "Jane Smith",
+      role: "teacher",
+      employment_status: "active",
       class_subjects: [
-        { id: 1, name: 'english' },
-        { id: 4, name: 'science' },
+        { id: 1, name: "english" },
+        { id: 4, name: "science" },
       ],
       studentsCount: 1,
-      current_sign_in_at: '2024-01-01T12:00:00Z',
+      current_sign_in_at: "2024-01-01T12:00:00Z",
     });
 
     // 詳細データ検索の検証（teacher1）
     const detail2 = detailDrawer.find((detail) => detail.id === 2);
     expect(detail2).toEqual({
       id: 2,
-      name: 'Jane Smith',
-      role: 'teacher',
-      email: 'jane.smith@example.com',
-      created_at: '2024-01-01T12:00:00Z',
-      employment_status: 'active',
-      current_sign_in_at: '2024-01-01T12:00:00Z',
+      name: "Jane Smith",
+      role: "teacher",
+      email: "jane.smith@example.com",
+      created_at: "2024-01-01T12:00:00Z",
+      employment_status: "active",
+      current_sign_in_at: "2024-01-01T12:00:00Z",
       students: [
         {
           id: 3,
-          name: 'Student Three',
-          status: 'active',
-          school_stage: 'junior_high_school',
+          name: "Student Three",
+          status: "active",
+          school_stage: "junior_high_school",
           grade: 2,
         },
       ],
       available_days: [
-        { id: 3, name: 'tuesday' },
-        { id: 5, name: 'thursday' },
+        { id: 3, name: "tuesday" },
+        { id: 5, name: "thursday" },
       ],
       class_subjects: [
-        { id: 1, name: 'english' },
-        { id: 4, name: 'science' },
+        { id: 1, name: "english" },
+        { id: 4, name: "science" },
       ],
     });
 
@@ -96,7 +96,7 @@ describe('useFormatTeachersData', () => {
     expect(setDetailDrawerSpy).toHaveBeenCalled();
   });
 
-  test('should exclude null elements in teachersData (via filter(Boolean))', () => {
+  test("should exclude null elements in teachersData (via filter(Boolean))", () => {
     const teachersResponse = [teacher1, null] as unknown as currentUser[];
     const loading = false;
     renderHook(() =>
@@ -108,7 +108,7 @@ describe('useFormatTeachersData', () => {
     expect(dataTable.map((r) => r.id)).toEqual([1, 2]);
   });
 
-  test('should return only teachers when currentUser is missing', () => {
+  test("should return only teachers when currentUser is missing", () => {
     const teachersResponse = [teacher1] as unknown as currentUser[];
     const loading = false;
 
@@ -118,15 +118,15 @@ describe('useFormatTeachersData', () => {
     expect(dataTable).toHaveLength(1);
     expect(dataTable[0]).toEqual({
       id: 2,
-      name: 'Jane Smith',
-      role: 'teacher',
-      employment_status: 'active',
+      name: "Jane Smith",
+      role: "teacher",
+      employment_status: "active",
       class_subjects: [
-        { id: 1, name: 'english' },
-        { id: 4, name: 'science' },
+        { id: 1, name: "english" },
+        { id: 4, name: "science" },
       ],
       studentsCount: 1,
-      current_sign_in_at: '2024-01-01T12:00:00Z',
+      current_sign_in_at: "2024-01-01T12:00:00Z",
     });
 
     // currentUser はidが1, teacher はidが2
@@ -134,10 +134,10 @@ describe('useFormatTeachersData', () => {
     const teacher = detailDrawer.find((detail) => detail.id === 2);
 
     expect(currentUser).toBeUndefined();
-    expect(teacher?.email).toBe('jane.smith@example.com');
+    expect(teacher?.email).toBe("jane.smith@example.com");
   });
 
-  test('should return an empty array and undefined for lookups when both currentUser and teachersData are missing', () => {
+  test("should return an empty array and undefined for lookups when both currentUser and teachersData are missing", () => {
     const loading = false;
     renderHook(() => useFormatTeachersData(null, null, !loading));
     const { dataTable, detailDrawer } = useTeachersStore.getState();
@@ -147,7 +147,7 @@ describe('useFormatTeachersData', () => {
     expect(currentUser).toBeUndefined();
   });
 
-  test('does not update store when loading is true', () => {
+  test("does not update store when loading is true", () => {
     const teachersResponse = [teacher1] as unknown as currentUser[];
     const loading = true;
     renderHook(() =>
@@ -162,7 +162,7 @@ describe('useFormatTeachersData', () => {
     expect(setDetailDrawerSpy).not.toHaveBeenCalled();
   });
 
-  test('does not update store when prev is equal to same', () => {
+  test("does not update store when prev is equal to same", () => {
     const teachersResponse = [teacher1] as unknown as currentUser[];
     const loading = false;
 

--- a/src/features/teachers/types/teacherForm.ts
+++ b/src/features/teachers/types/teacherForm.ts
@@ -1,3 +1,5 @@
+import type { teacherDetailDrawer } from "./teachers";
+
 // toggleInArray を使用するkey の型
 export type ToggleableKeys = "subjects" | "available_days";
 
@@ -23,4 +25,5 @@ export type TeacherFormProps = {
   setFormData: setFormDataType;
   handleClose: () => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  teacher: teacherDetailDrawer | undefined;
 };

--- a/src/tests/fixtures/teachers/teachers.ts
+++ b/src/tests/fixtures/teachers/teachers.ts
@@ -60,7 +60,7 @@ export const currentUserResponse = {
   created_at: "2023-01-01T12:00:00Z",
   employment_status: "active",
   current_sign_in_at: "2023-01-01T12:00:00Z",
-  students: [student1, student2],
+  students: [],
   available_days: [
     AVAILABLE_DAYS_MOCK[1], // 月曜日
     AVAILABLE_DAYS_MOCK[3], // 水曜日


### PR DESCRIPTION
## ISSUE

close #111 

## 実装概要

<!-- この PR の目的・背景を 1～2 行で記載してください（例：バグ修正、UI改善、パフォーマンス向上など） -->
### 教師編集フォームのガード強化
- Teacher が生徒を担当している場合、編集フォーム内で警告表示に切替え（科目/曜日の編集 UI は非表示）
- 担当生徒の一覧を表示し、「生徒一覧へ」ボタンを追加


## スクリーンショット

<!-- 変更前後のスクリーンショットやGIFを貼ってください。なければ省略可能です -->

## 動作確認手順

<!-- レビュアーが確認しやすいように、操作手順を具体的に記載してください -->

1. 講師編集画面を開く
2. 講師がいる場合は、生徒が表示されて科目と曜日の編集ができないようにする

## 影響範囲

<!-- この変更が影響する画面・機能・ファイルなどを記載してください（例：todo一覧画面、Userモデルなど） -->
- 教師が担当生徒を持つ場合の編集制限の仕様が妥当か
- 生徒編集ルートの権限を admin のみに統一した点が意図通りか（破壊的変更の可能性）
- EditStudentDialog の初期化順序により例外が発生しないか
- テスト/フィクスチャの変更が実態と合っているか

## レビューポイント

<!-- レビュアーに特に見てほしい点があればチェックを入れてください -->

- [ ] **機能**：仕様どおりに動作するか
- [ ] **コード品質**：可読性・保守性
- [ ] **セキュリティ**：権限・バリデーション・入力チェック
- [ ] **パフォーマンス**：処理速度やリソース使用量
- [ ] **CI**：GitHub Actions のワークフローが成功しているか

## デプロイ／運用

<!-- 該当する項目にチェックを入れて、必要に応じて補足してください -->

- **マイグレーション**：無
- **環境変数の追加**：無
- **破壊的変更の有無**：有（生徒編集ルートを admin 限定に変更）

## チェックリスト（作成者用）

<!-- PR作成前に確認した内容にチェックを入れてください -->

- [ ] 自身で動作確認・コードレビューを完了した
- [ ] 不要なコメント・デバッグコードを削除した
- [ ] コミットメッセージがわかりやすく記述されている
- [ ] 関連 Issue がリンクされている（あれば）

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか
