### PR TITLE
student編集時に今までやっていた科目を削除した場合に確認ダイアログが出るようにした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -1301,6 +1302,34 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/src/components/common/status/ConfirmDialog.tsx
+++ b/src/components/common/status/ConfirmDialog.tsx
@@ -1,0 +1,48 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/feedback/Alert/alert-dialog";
+import type { JSX } from "react";
+
+type ConfirmDialogProps = {
+  title: string;
+  description: JSX.Element | string;
+  confirmText: string;
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  onOpenChange: (open: boolean) => void;
+};
+
+export const ConfirmDialog = ({
+  title,
+  description,
+  confirmText,
+  open,
+  onCancel,
+  onConfirm,
+  onOpenChange,
+}: ConfirmDialogProps) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>キャンセル</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            {confirmText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/components/test/common/status/ConfirmDialog.test.tsx
+++ b/src/components/test/common/status/ConfirmDialog.test.tsx
@@ -1,0 +1,54 @@
+import { ConfirmDialog } from "@/components/common/status/ConfirmDialog";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const onCancel = vi.fn();
+const onConfirm = vi.fn();
+const onOpenChange = vi.fn();
+
+describe("ConfirmDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  test("renders correctly with jsx description", () => {
+    const mockProps = {
+      title: "Confirm Action",
+      description: (
+        <>
+          <span>Are you sure you want to proceed?</span>
+        </>
+      ),
+      confirmText: "Confirm",
+      open: true,
+      onCancel,
+      onConfirm,
+      onOpenChange,
+    };
+    render(<ConfirmDialog {...mockProps} />);
+    expect(screen.getByText("Confirm Action")).toBeInTheDocument();
+    expect(
+      screen.getByText("Are you sure you want to proceed?")
+    ).toBeInTheDocument();
+    expect(screen.getByText("キャンセル")).toBeInTheDocument();
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+  });
+
+  test("renders correctly with string description", () => {
+    const mockProps = {
+      title: "Confirm Action",
+      description: "Are you sure you want to proceed?",
+      confirmText: "Confirm",
+      open: true,
+      onCancel,
+      onConfirm,
+      onOpenChange,
+    };
+    render(<ConfirmDialog {...mockProps} />);
+    expect(screen.getByText("Confirm Action")).toBeInTheDocument();
+    expect(
+      screen.getByText("Are you sure you want to proceed?")
+    ).toBeInTheDocument();
+    expect(screen.getByText("キャンセル")).toBeInTheDocument();
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/feedback/Alert/alert-dialog.tsx
+++ b/src/components/ui/feedback/Alert/alert-dialog.tsx
@@ -1,0 +1,155 @@
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "../../form/Button/button";
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  );
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  );
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/features/students/components/StudentForm/StudentForm.tsx
+++ b/src/features/students/components/StudentForm/StudentForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState, useEffect, useRef } from "react";
 import type {
   StudentFormMode,
   StudentFormProps,
@@ -26,6 +26,7 @@ import { DayCheckboxes } from "./parts/DayCheckboxes";
 import { TeacherAssignmentTabs } from "./parts/TeacherAssignmentTabs";
 import { SelectedAssignmentsBadges } from "./parts/SelectedAssignmentsBadges";
 import { Button } from "@/components/ui/form/Button/button";
+import { ConfirmDialog } from "@/components/common/status/ConfirmDialog";
 
 export const StudentForm = <M extends StudentFormMode>({
   mode,
@@ -37,19 +38,31 @@ export const StudentForm = <M extends StudentFormMode>({
 }: StudentFormProps<M>) => {
   // フォーム操作ハンドラ
   const H = createStudentFormHandlers(onChange);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<string | null>(null);
 
   // すでに選択された科目・曜日
   const selectedSubjectIds = value.subject_ids ?? [];
   const selectedDayIds = value.available_day_ids ?? [];
 
-  // 講師リスト(すべて・曜日ごと)をタブ表示用に変換
+  // 初期 subject_ids を固定スナップショット
+  const initialSubjectIdsRef = useRef<number[] | null>(null);
+  if (mode === "edit" && initialSubjectIdsRef.current === null) {
+    initialSubjectIdsRef.current = [...selectedSubjectIds];
+  }
+
+  // 初期値から外れた科目IDの配列
+  const removeSubjectIds = useMemo(() => {
+    if (mode !== "edit") return [];
+    const init = new Set(initialSubjectIdsRef.current ?? []);
+    return [...init].filter((id) => !selectedSubjectIds.includes(id));
+  }, [mode, selectedSubjectIds]);
+
   const teachersByTab = useMemo(
     () => buildTeachersByTab(teachers, selectedSubjectIds, ALL_DAY_IDS),
     [teachers, selectedSubjectIds]
   );
 
-  // タブ自動選択
-  const [activeTab, setActiveTab] = useState<string | null>(null);
   useEffect(() => {
     if (
       selectedDayIds.length > 0 &&
@@ -68,120 +81,149 @@ export const StudentForm = <M extends StudentFormMode>({
   const variant = mode === "edit" ? "EditDraft" : "Draft";
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        onSubmit(value);
-      }}
-      className="px-4 sm:px-6 py-6 space-y-5"
-    >
-      <div className="space-y-4">
-        <NameField
-          variant={variant}
-          value={value}
-          onChange={H.handleInputChange}
-        />
+    <>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
 
-        <LevelSelect value={value} onChange={H.handleStudentOptionChange} />
+          if (mode === "edit" && removeSubjectIds.length > 0) {
+            setConfirmOpen(true);
+            return;
+          }
+          onSubmit(value);
+        }}
+        className="px-4 sm:px-6 py-6 space-y-5"
+      >
+        <div className="space-y-4">
+          <NameField
+            variant={variant}
+            value={value}
+            onChange={H.handleInputChange}
+          />
 
-        <DesiredSchoolField value={value} onChange={H.handleInputChange} />
+          <LevelSelect value={value} onChange={H.handleStudentOptionChange} />
 
-        <JoinedOnPicker
-          value={value}
-          onChange={H.handleSelectChange("joined_on")}
-        />
-        {/** TeacherFormでも利用しているため、statusとして渡している
-         */}
-        <StatusSelect
-          variant={variant}
-          status={value.status}
-          onChange={H.handleSelectChange("status")}
-        />
+          <DesiredSchoolField value={value} onChange={H.handleInputChange} />
 
-        <SubjectCheckboxes
-          value={value}
-          toggle={(id: number) => H.toggleInArray("subject_ids", id)}
-        />
+          <JoinedOnPicker
+            value={value}
+            onChange={H.handleSelectChange("joined_on")}
+          />
+          {/** TeacherFormでも利用しているため、statusとして渡している
+           */}
+          <StatusSelect
+            variant={variant}
+            status={value.status}
+            onChange={H.handleSelectChange("status")}
+          />
 
-        <DayCheckboxes
-          value={value}
-          toggle={(id: number) => H.toggleInArray("available_day_ids", id)}
-        />
+          <SubjectCheckboxes
+            value={value}
+            toggle={(id: number) => H.toggleInArray("subject_ids", id)}
+          />
 
-        {/* 担当講師 */}
-        {activeTab === null ? (
-          <div className="rounded-md border p-3 text-center space-y-1.5">
-            <p className="text-sm font-medium">
-              受講科目と受講可能曜日を選ぶと、担当できる講師が表示されます
-            </p>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            <div className="text-sm font-medium">担当講師を選択</div>
-            <span className="text-muted-foreground text-sm">
-              科目と曜日で絞り込みされています。
-            </span>
+          <DayCheckboxes
+            value={value}
+            toggle={(id: number) => H.toggleInArray("available_day_ids", id)}
+          />
 
-            <Tabs
-              value={activeTab ?? undefined}
-              onValueChange={setActiveTab}
-              className="w-full"
-            >
-              <TabsList className="flex flex-wrap">
+          {/* 担当講師 */}
+          {activeTab === null ? (
+            <div className="rounded-md border p-3 text-center space-y-1.5">
+              <p className="text-sm font-medium">
+                受講科目と受講可能曜日を選ぶと、担当できる講師が表示されます
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <div className="text-sm font-medium">担当講師を選択</div>
+              <span className="text-muted-foreground text-sm">
+                科目と曜日で絞り込みされています。
+              </span>
+
+              <Tabs
+                value={activeTab ?? undefined}
+                onValueChange={setActiveTab}
+                className="w-full"
+              >
+                <TabsList className="flex flex-wrap">
+                  {selectedDayIds
+                    .sort((a, b) => a - b)
+                    .map((id) => {
+                      const label =
+                        DAY_OF_WEEK_WITH_ID.find((day) => day.id === id)
+                          ?.name ?? "？";
+                      return (
+                        <TabsTrigger key={id} value={String(id)}>
+                          {shortDayLabel(label)}
+                        </TabsTrigger>
+                      );
+                    })}
+                </TabsList>
+
                 {selectedDayIds
                   .sort((a, b) => a - b)
-                  .map((id) => {
-                    const label =
-                      DAY_OF_WEEK_WITH_ID.find((day) => day.id === id)?.name ??
-                      "？";
-                    return (
-                      <TabsTrigger key={id} value={String(id)}>
-                        {shortDayLabel(label)}
-                      </TabsTrigger>
-                    );
-                  })}
-              </TabsList>
-
-              {selectedDayIds
-                .sort((a, b) => a - b)
-                .map((dayId) => (
-                  <TabsContent
-                    key={dayId}
-                    value={String(dayId)}
-                    className="mt-3"
-                  >
-                    <div
-                      className={cn(
-                        "overflow-y-auto rounded-md border p-3 space-y-2",
-                        "max-h-60"
-                      )}
+                  .map((dayId) => (
+                    <TabsContent
+                      key={dayId}
+                      value={String(dayId)}
+                      className="mt-3"
                     >
-                      <TeacherAssignmentTabs
-                        dayId={dayId}
-                        teachers={teachersByTab.byDay[dayId] ?? []}
-                        selectedSubjectIds={selectedSubjectIds}
-                        assigned={value.assignments}
-                        toggle={H.toggleAssignmentInForm}
-                      />
-                    </div>
-                  </TabsContent>
-                ))}
-            </Tabs>
+                      <div
+                        className={cn(
+                          "overflow-y-auto rounded-md border p-3 space-y-2",
+                          "max-h-60"
+                        )}
+                      >
+                        <TeacherAssignmentTabs
+                          dayId={dayId}
+                          teachers={teachersByTab.byDay[dayId] ?? []}
+                          selectedSubjectIds={selectedSubjectIds}
+                          assigned={value.assignments}
+                          toggle={H.toggleAssignmentInForm}
+                        />
+                      </div>
+                    </TabsContent>
+                  ))}
+              </Tabs>
 
-            <SelectedAssignmentsBadges
-              assignments={value.assignments}
-              teachers={teachers}
-              untoggle={H.toggleAssignmentInForm}
-            />
-          </div>
-        )}
-      </div>
+              <SelectedAssignmentsBadges
+                assignments={value.assignments}
+                teachers={teachers}
+                untoggle={H.toggleAssignmentInForm}
+              />
+            </div>
+          )}
+        </div>
 
-      <div className="mt-6 gap-2 sm:justify-between">
-        <Button type="submit" disabled={loading}>
-          {mode === "edit" ? "更新" : "作成"}
-        </Button>
-      </div>
-    </form>
+        <div className="mt-6 gap-2 sm:justify-between">
+          <Button type="submit" disabled={loading}>
+            {mode === "edit" ? "更新" : "作成"}
+          </Button>
+        </div>
+      </form>
+      {mode === "edit" && removeSubjectIds.length > 0 && (
+        <ConfirmDialog
+          title="本当に更新しますか？"
+          description={
+            <>
+              更新すると、
+              <span className="text-destructive">
+                選択を外した科目に関連する授業引継ぎメモは削除されます
+              </span>
+              。 この操作は元に戻せません。続行しますか？
+            </>
+          }
+          confirmText={"削除して更新する"}
+          open={confirmOpen}
+          onCancel={() => setConfirmOpen(false)}
+          onConfirm={() => {
+            onSubmit(value);
+            setConfirmOpen(false);
+          }}
+          onOpenChange={setConfirmOpen}
+        />
+      )}
+    </>
   );
 };

--- a/src/tests/integration/students/studentUpdate.test.tsx
+++ b/src/tests/integration/students/studentUpdate.test.tsx
@@ -79,6 +79,35 @@ describe("Student Update Page", () => {
     expect(await screen.findByText("生徒を更新しました")).toBeInTheDocument();
   }, 20000);
 
+  test("should display a confirmation dialog when removing subjects that have lesson notes", async () => {
+    const user = userEvent.setup();
+    updateRender();
+
+    expect(await screen.findByText("mockStudent One")).toBeInTheDocument();
+    const studentMenuButton = getMenuButtonById(STUDENT1_ID);
+    await user.click(studentMenuButton);
+
+    // 編集をクリック
+    const editMenuButton = screen.getByRole("menuitem", { name: "編集" });
+    await user.click(editMenuButton);
+
+    expect(await screen.findByText("生徒情報を編集")).toBeInTheDocument();
+
+    // 科目の選択を外す (数学を外す)
+    const mathCheckbox = screen.getByRole("checkbox", { name: "数学" });
+    await user.click(mathCheckbox);
+    expect(mathCheckbox).not.toBeChecked();
+
+    const updateButton = screen.getByRole("button", { name: "更新" });
+    await user.click(updateButton);
+
+    // 確認ダイアログが表示される
+    expect(await screen.findByText("本当に更新しますか？")).toBeInTheDocument();
+    expect(
+      screen.getByText(/選択を外した科目に関連する授業引継ぎメモは削除されます/)
+    ).toBeInTheDocument();
+  });
+
   test("should display validation errors when submitting an empty form", async () => {
     const user = userEvent.setup();
     updateRender();


### PR DESCRIPTION
## ISSUE

close #158 

## 実装概要

<!-- この PR の目的・背景を 1～2 行で記載してください（例：バグ修正、UI改善、パフォーマンス向上など） -->
### 依存追加

@radix-ui/react-alert-dialog を追加
### 共通UI

- ConfirmDialog を新規追加（Radix AlertDialog ラッパー）
- ui/feedback/Alert/alert-dialog.tsx を実装（Radix の薄いラッパーとスタイル）
### 学生フォーム

- StudentForm に確認ダイアログを統合
- 編集モード時、初期の subject_ids を useRef でスナップショット
- 現在の選択から外れた科目IDを removeSubjectIds として算出
- removeSubjectIds がある状態で「更新」を押すと ConfirmDialog を表示
- 確認ダイアログの「削除して更新する」で実際の onSubmit を実行
- キャンセルでダイアログを閉じ、送信しない
- 既存のフォーム構造やハンドラは変更なし
### テスト

- ConfirmDialog のユニットテストを追加（JSX/文字列 description 両対応）
- studentUpdate の統合テ

## スクリーンショット

<!-- 変更前後のスクリーンショットやGIFを貼ってください。なければ省略可能です -->

## 動作確認手順

<!-- レビュアーが確認しやすいように、操作手順を具体的に記載してください -->
1. 生徒一覧 → 任意の生徒で「編集」を開く
2. 既に選択済みの科目（例: 数学）のチェックを外す
3. 「更新」をクリック
  - 「本当に更新しますか？」ダイアログが表示されること
  - 警告文に「選択を外した科目に関連する授業引継ぎメモは削除されます」と出ること
4. 「削除して更新する」をクリック
  - 更新が完了し、トーストが表示されること
5. 「キャンセル」をクリック
  - ダイアログが閉じ、更新は行われないこと

## 影響範囲

<!-- この変更が影響する画面・機能・ファイルなどを記載してください（例：todo一覧画面、Userモデルなど） -->
- 生徒編集フォーム（編集モードの送信フロー）
- 共通UI（AlertDialog ラッパー追加）
- 依存関係（Radix AlertDialog の追加）

## レビューポイント

<!-- レビュアーに特に見てほしい点があればチェックを入れてください -->

- [ ] **機能**：仕様どおりに動作するか
- [ ] **コード品質**：可読性・保守性
- [ ] **セキュリティ**：権限・バリデーション・入力チェック
- [ ] **パフォーマンス**：処理速度やリソース使用量
- [ ] **CI**：GitHub Actions のワークフローが成功しているか

## デプロイ／運用

<!-- 該当する項目にチェックを入れて、必要に応じて補足してください -->

- **マイグレーション**：無
- **環境変数の追加**：無
- **破壊的変更の有無**：無

## チェックリスト（作成者用）

<!-- PR作成前に確認した内容にチェックを入れてください -->

- [ ] 自身で動作確認・コードレビューを完了した
- [ ] 不要なコメント・デバッグコードを削除した
- [ ] コミットメッセージがわかりやすく記述されている
- [ ] 関連 Issue がリンクされている（あれば）

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか
