### PR TITLE
Lesson_note の新規作成、編集周りのテスト追加

### DIFF
--- a/src/features/lessonNotes/components/LessonNoteForm/LessonNoteForm.tsx
+++ b/src/features/lessonNotes/components/LessonNoteForm/LessonNoteForm.tsx
@@ -33,7 +33,6 @@ export const LessonNoteForm = <M extends Mode>({
           <SubjectField subject_id={value.subject_id} subjects={subjects} />
         ) : (
           <SubjectSelect
-            subjectId={value.subject_id}
             subjects={subjects}
             onChange={H.handleSelectChange("subject_id")}
           />

--- a/src/features/lessonNotes/components/LessonNoteForm/parts/DescriptionField.tsx
+++ b/src/features/lessonNotes/components/LessonNoteForm/parts/DescriptionField.tsx
@@ -3,7 +3,7 @@ import { Textarea } from "@/components/ui/form/TextArea/textarea";
 import type { LessonNoteFormValuesByMode } from "@/features/lessonNotes/types/lessonNoteForm";
 import type { Mode } from "@/features/students/types/studentForm";
 
-type DescriptionFieldProps<M extends Mode> = {
+export type DescriptionFieldProps<M extends Mode> = {
   description: string | null;
   onChange: (
     field: keyof LessonNoteFormValuesByMode<M>

--- a/src/features/lessonNotes/components/LessonNoteForm/parts/NoteTypeSelect.tsx
+++ b/src/features/lessonNotes/components/LessonNoteForm/parts/NoteTypeSelect.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/features/lessonNotes/constants/lessonNoteTable";
 import type { NoteType } from "@/features/lessonNotes/types/lessonNote";
 
-type NoteTypeSelectProps = {
+export type NoteTypeSelectProps = {
   noteType?: NoteType;
   onChange: (value: NoteType) => void;
 };

--- a/src/features/lessonNotes/components/LessonNoteForm/parts/SubjectField.tsx
+++ b/src/features/lessonNotes/components/LessonNoteForm/parts/SubjectField.tsx
@@ -2,7 +2,7 @@ import { Label } from "@/components/ui/form/Label/label";
 import type { ClassSubjectType } from "@/features/students/types/students";
 import { subjectBadgeUtils } from "@/utils/subjectBadgeUtils";
 
-type SubjectFieldProps = {
+export type SubjectFieldProps = {
   subject_id?: number;
   subjects: ClassSubjectType[];
 };

--- a/src/features/lessonNotes/components/LessonNoteForm/parts/SubjectSelect.tsx
+++ b/src/features/lessonNotes/components/LessonNoteForm/parts/SubjectSelect.tsx
@@ -9,20 +9,17 @@ import {
 import { SUBJECT_JA_NAMES } from "@/constants/subjectTranslations";
 
 import type { ClassSubjectType } from "@/features/students/types/students";
+import { useState } from "react";
 
-type SubjectSelectProps = {
-  subjectId?: number;
+export type SubjectSelectProps = {
   subjects: ClassSubjectType[];
   onChange: (value: number) => void;
 };
 
-export const SubjectSelect = ({
-  subjectId,
-  subjects,
-  onChange,
-}: SubjectSelectProps) => {
-  const value = subjectId ? String(subjectId) : undefined;
+export const SubjectSelect = ({ subjects, onChange }: SubjectSelectProps) => {
+  const [value, setValue] = useState<string | undefined>(undefined);
   const handleChange = (value: string) => {
+    setValue(value);
     onChange(Number(value));
   };
   return (

--- a/src/features/lessonNotes/components/LessonNoteForm/parts/TitleField.tsx
+++ b/src/features/lessonNotes/components/LessonNoteForm/parts/TitleField.tsx
@@ -3,7 +3,7 @@ import { Input } from "@/components/ui/form/Input/input";
 import type { LessonNoteFormValuesByMode } from "@/features/lessonNotes/types/lessonNoteForm";
 import type { Mode } from "@/features/students/types/studentForm";
 
-type TitleFieldProps<M extends Mode> = {
+export type TitleFieldProps<M extends Mode> = {
   title: string;
   onChange: (
     field: keyof LessonNoteFormValuesByMode<M>

--- a/src/features/lessonNotes/components/dialog/CreateLessonNoteDialog.tsx
+++ b/src/features/lessonNotes/components/dialog/CreateLessonNoteDialog.tsx
@@ -18,13 +18,15 @@ import { useLessonNoteForm } from "../../hooks/useLessonNoteForm";
 import type { ClassSubjectType } from "@/features/students/types/students";
 import { useCreateLessonNoteMutation } from "../../mutations/useCreateLessonNoteMutation";
 
+export type CreateLessonNoteDialogProps = {
+  studentId: number;
+  subjects: ClassSubjectType[];
+};
+
 export const CreateLessonNoteDialog = ({
   studentId,
   subjects,
-}: {
-  studentId: number;
-  subjects: ClassSubjectType[];
-}) => {
+}: CreateLessonNoteDialogProps) => {
   const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
   const { value, setValue, submit, reset } = useLessonNoteForm("create");

--- a/src/features/lessonNotes/components/drawer/LessonNoteDrawer.tsx
+++ b/src/features/lessonNotes/components/drawer/LessonNoteDrawer.tsx
@@ -14,7 +14,7 @@ import { IconX } from "@tabler/icons-react";
 import { formatIsoToDate } from "@/utils/formatIsoToDate";
 import type { lessonNoteType } from "../../types/lessonNote";
 
-type Props = {
+export type LessonNoteDrawerProps = {
   lessonNote: Pick<
     lessonNoteType,
     | "title"
@@ -27,7 +27,7 @@ type Props = {
   >;
 };
 
-export const LessonNoteDrawer = ({ lessonNote }: Props) => {
+export const LessonNoteDrawer = ({ lessonNote }: LessonNoteDrawerProps) => {
   const {
     title,
     description,
@@ -63,32 +63,32 @@ export const LessonNoteDrawer = ({ lessonNote }: Props) => {
         </DrawerHeader>
         <div className="flex flex-col gap-4 overflow-y-auto px-4 py-2 text-sm">
           <div className="flex flex-col gap-2">
-            <Label htmlFor="expireDate">有効期限</Label>
+            <Label>有効期限</Label>
             <p id="expireDate" className="text-muted-foreground">
               {expireDate}
             </p>
           </div>
           <div className="flex flex-col gap-2">
-            <Label htmlFor="createdBy">作成者</Label>
+            <Label>作成者</Label>
             <p id="createdBy" className="text-muted-foreground">
               {created_by_name}
             </p>
           </div>
           <div className="flex flex-col gap-2">
-            <Label htmlFor="createdAt">作成日</Label>
+            <Label>作成日</Label>
             <p id="createdAt" className="text-muted-foreground">
               {formatIsoToDate(created_at)}
             </p>
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="lastUpdatedBy">最終更新者</Label>
+            <Label>最終更新者</Label>
             <div id="lastUpdatedBy" className="text-muted-foreground">
               {last_updated_by_name ? last_updated_by_name : "---"}
             </div>
           </div>
           <div className="flex flex-col gap-2">
-            <Label htmlFor="lastUpdatedAt">最終更新日</Label>
+            <Label>最終更新日</Label>
             <p id="lastUpdatedAt" className="text-muted-foreground">
               {created_at === updated_at ? "---" : formatIsoToDate(updated_at)}
             </p>

--- a/src/features/lessonNotes/queries/useLessonNotesQuery.ts
+++ b/src/features/lessonNotes/queries/useLessonNotesQuery.ts
@@ -3,7 +3,6 @@ import { lessonNoteKeys, type LessonNoteListFilters } from "../key";
 import type { FetchLessonNotesResponse } from "../types/lessonNote";
 import { FetchLessonNotes } from "../api/lessonNotesApi";
 
-// EditLessonNoteDialog で利用
 type Opts = { enabled?: boolean };
 export const useLessonNotesQuery = (
   filters: LessonNoteListFilters,

--- a/src/features/lessonNotes/test/api/lessonNoteCreateApi.test.ts
+++ b/src/features/lessonNotes/test/api/lessonNoteCreateApi.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { api } from "@/lib/api";
+import {
+  createLessonNotePayload,
+  createResponseLessonNoteMock,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+import { CreateLessonNote } from "../../api/lessonNoteCreateApi";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    post: vi.fn(),
+  },
+}));
+
+describe("lessonNoteCreateApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("CreateLessonNote", async () => {
+    const mockResponse = {
+      data: {
+        ...createResponseLessonNoteMock,
+      },
+    };
+
+    vi.mocked(api.post).mockResolvedValueOnce(mockResponse);
+
+    const result = await CreateLessonNote(createLessonNotePayload);
+    expect(result).toEqual(createResponseLessonNoteMock);
+    expect(api.post).toHaveBeenCalledWith("/lesson_notes", {
+      ...createLessonNotePayload,
+    });
+  });
+
+  test("CreateLessonNote - handles API error", async () => {
+    const apiError = new Error("API Error");
+    vi.mocked(api.post).mockRejectedValueOnce(apiError);
+
+    await expect(CreateLessonNote(createLessonNotePayload)).rejects.toThrow(
+      "API Error"
+    );
+  });
+
+  test("CreateLessonNote - handles invalid response data", async () => {
+    const invalidResponse = {
+      data: {
+        invalid: "data",
+      },
+    };
+
+    vi.mocked(api.post).mockResolvedValueOnce(invalidResponse);
+
+    // Zodエラーがスローされることを確認
+    await expect(CreateLessonNote(createLessonNotePayload)).rejects.toThrow();
+  });
+});

--- a/src/features/lessonNotes/test/api/lessonNoteUpdateApi.test.ts
+++ b/src/features/lessonNotes/test/api/lessonNoteUpdateApi.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { api } from "@/lib/api";
+import {
+  editLessonNotePayload,
+  editResponseLessonNoteMock,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+import { UpdateLessonNote } from "../../api/lessonNoteUpdateApi";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    patch: vi.fn(),
+  },
+}));
+
+describe("lessonNoteUpdateApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("UpdateLessonNote", async () => {
+    const mockResponse = {
+      data: {
+        ...editResponseLessonNoteMock,
+      },
+    };
+
+    vi.mocked(api.patch).mockResolvedValueOnce(mockResponse);
+
+    const result = await UpdateLessonNote(editLessonNotePayload);
+    expect(result).toEqual(editResponseLessonNoteMock);
+    expect(api.patch).toHaveBeenCalledWith(
+      `/lesson_notes/${editLessonNotePayload.id}`,
+      {
+        ...editLessonNotePayload,
+      }
+    );
+  });
+
+  test("updateLessonNote - handles API error", async () => {
+    const apiError = new Error("API Error");
+    vi.mocked(api.patch).mockRejectedValueOnce(apiError);
+
+    await expect(UpdateLessonNote(editLessonNotePayload)).rejects.toThrow(
+      "API Error"
+    );
+  });
+
+  test("updateLessonNote - handles invalid response data", async () => {
+    const invalidResponse = {
+      data: {
+        invalid: "data",
+      },
+    };
+
+    vi.mocked(api.patch).mockResolvedValueOnce(invalidResponse);
+
+    // Zodエラーがスローされることを確認
+    await expect(UpdateLessonNote(editLessonNotePayload)).rejects.toThrow();
+  });
+});

--- a/src/features/lessonNotes/test/api/lessonNotesApi.test.ts
+++ b/src/features/lessonNotes/test/api/lessonNotesApi.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { api } from "@/lib/api";
+import {
+  LessonNotesMeta,
+  lessonNotesMock,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+import type { LessonNoteListFilters } from "../../key";
+import { FetchLessonNotes } from "../../api/lessonNotesApi";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+describe("lessonNotesApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("FetchLessonNotes", async () => {
+    const mockResponse = {
+      data: {
+        lesson_notes: lessonNotesMock,
+        meta: LessonNotesMeta,
+      },
+    };
+
+    vi.mocked(api.get).mockResolvedValueOnce(mockResponse);
+
+    const mockFilters: LessonNoteListFilters = {
+      student_id: 1, //student1
+      subject_id: 1, // 英語
+      searchKeyword: undefined,
+      page: 1,
+      perPage: 10,
+    };
+
+    const result = await FetchLessonNotes(mockFilters);
+    expect(result).toEqual({
+      lesson_notes: lessonNotesMock,
+      meta: LessonNotesMeta,
+    });
+    expect(api.get).toHaveBeenCalledWith("/lesson_notes", {
+      params: mockFilters,
+    });
+  });
+
+  test("FetchLessonNotes - handles API error", async () => {
+    const apiError = new Error("API Error");
+    vi.mocked(api.get).mockRejectedValueOnce(apiError);
+
+    const mockFilters: LessonNoteListFilters = {
+      student_id: 1,
+      subject_id: 1,
+      searchKeyword: undefined,
+      page: 1,
+      perPage: 10,
+    };
+
+    await expect(FetchLessonNotes(mockFilters)).rejects.toThrow("API Error");
+  });
+
+  test("FetchLessonNotes - handles invalid response data", async () => {
+    const invalidResponse = {
+      data: {
+        // lesson_notes プロパティが欠けている不正なレスポンス
+        meta: LessonNotesMeta,
+      },
+    };
+
+    vi.mocked(api.get).mockResolvedValueOnce(invalidResponse);
+
+    const mockFilters: LessonNoteListFilters = {
+      student_id: 1,
+      subject_id: 1,
+      searchKeyword: undefined,
+      page: 1,
+      perPage: 10,
+    };
+
+    // Zodエラーがスローされることを確認
+    await expect(FetchLessonNotes(mockFilters)).rejects.toThrow();
+  });
+});

--- a/src/features/lessonNotes/test/components/dialog/CreateLessonNoteDialog.test.tsx
+++ b/src/features/lessonNotes/test/components/dialog/CreateLessonNoteDialog.test.tsx
@@ -1,0 +1,225 @@
+import { Toaster } from "@/components/ui/feedback/Sonner/sonner";
+import {
+  CreateLessonNoteDialog,
+  type CreateLessonNoteDialogProps,
+} from "@/features/lessonNotes/components/dialog/CreateLessonNoteDialog";
+import { useLessonNoteForm } from "@/features/lessonNotes/hooks/useLessonNoteForm";
+import { useCreateLessonNoteMutation } from "@/features/lessonNotes/mutations/useCreateLessonNoteMutation";
+import type { LessonNoteCreate } from "@/features/lessonNotes/types/lessonNote";
+import {
+  initialLessonFormCreateMockValue,
+  lessonNoteCreateFormMockValue,
+  mockSubjects,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    mutations: { retry: false },
+  },
+});
+
+const wrapper = (props: CreateLessonNoteDialogProps) => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Toaster />
+      <CreateLessonNoteDialog {...props} />
+    </QueryClientProvider>
+  );
+};
+
+vi.mock("@/features/lessonNotes/mutations/useCreateLessonNoteMutation", () => ({
+  useCreateLessonNoteMutation: vi.fn(),
+}));
+
+vi.mock("@/features/lessonNotes/hooks/useLessonNoteForm", () => ({
+  useLessonNoteForm: vi.fn(),
+}));
+const setValueMock = vi.fn();
+const resetMock = vi.fn();
+const mutateMock = vi.fn();
+
+describe("CreateLessonNoteDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+  });
+
+  test("should open and close the dialog correctly and reset the form", async () => {
+    const user = userEvent.setup();
+    const submitMock = vi.fn();
+
+    vi.mocked(useLessonNoteForm).mockReturnValue({
+      value: initialLessonFormCreateMockValue,
+      setValue: setValueMock,
+      submit: submitMock,
+      reset: resetMock,
+    });
+
+    vi.mocked(useCreateLessonNoteMutation).mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateLessonNoteMutation>);
+
+    const mockProps: CreateLessonNoteDialogProps = {
+      studentId: 1,
+      subjects: mockSubjects,
+    };
+
+    wrapper(mockProps);
+
+    const openButton = screen.getByRole("button", { name: /引継ぎ事項を追加/ });
+    expect(openButton).toBeInTheDocument();
+
+    await user.click(openButton);
+    expect(screen.getByText("引継ぎ事項を新規作成")).toBeInTheDocument();
+
+    const titleInput = screen.getByLabelText(/タイトル/);
+    await user.type(titleInput, "新しい引継ぎ事項のタイトル");
+    expect(setValueMock).toHaveBeenCalled();
+
+    // ダイアログを閉じる
+
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    expect(closeButton).toBeInTheDocument();
+    await user.click(closeButton);
+
+    expect(resetMock).toHaveBeenCalled();
+  });
+
+  test("should call mutate when form is submitted", async () => {
+    const user = userEvent.setup();
+
+    const submitMock = vi.fn(
+      (
+        onValid: (data: LessonNoteCreate) => void,
+        onInvalid?: (msgs: string[]) => void
+      ) => {
+        onValid(lessonNoteCreateFormMockValue);
+        onInvalid?.([]);
+        return true;
+      }
+    );
+
+    vi.mocked(useLessonNoteForm).mockReturnValue({
+      value: lessonNoteCreateFormMockValue,
+      setValue: setValueMock,
+      submit: submitMock,
+      reset: resetMock,
+    });
+
+    vi.mocked(useCreateLessonNoteMutation).mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateLessonNoteMutation>);
+
+    const mockProps: CreateLessonNoteDialogProps = {
+      studentId: 1,
+      subjects: mockSubjects,
+    };
+
+    wrapper(mockProps);
+
+    const openButton = screen.getByRole("button", { name: /引継ぎ事項を追加/ });
+    expect(openButton).toBeInTheDocument();
+
+    await user.click(openButton);
+    expect(screen.getByText("引継ぎ事項を新規作成")).toBeInTheDocument();
+
+    const submitButton = screen.getByRole("button", { name: "作成" });
+    expect(submitButton).toBeInTheDocument();
+
+    await user.click(submitButton);
+    expect(submitMock).toHaveBeenCalled();
+    expect(mutateMock).toHaveBeenCalledWith({
+      ...lessonNoteCreateFormMockValue,
+      student_id: 1,
+    });
+    expect(resetMock).toHaveBeenCalled();
+  });
+
+  test("should display error message when form is invalid", async () => {
+    const user = userEvent.setup();
+
+    const submitMock = vi.fn(
+      (
+        onValid: (data: LessonNoteCreate) => void,
+        onInvalid?: (msgs: string[]) => void
+      ) => {
+        onValid(lessonNoteCreateFormMockValue);
+        onInvalid?.(["タイトルは50文字以内で入力してください"]);
+        return false;
+      }
+    );
+
+    vi.mocked(useLessonNoteForm).mockReturnValue({
+      value: { ...lessonNoteCreateFormMockValue, title: "A".repeat(51) },
+      setValue: setValueMock,
+      submit: submitMock,
+      reset: resetMock,
+    });
+
+    vi.mocked(useCreateLessonNoteMutation).mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateLessonNoteMutation>);
+
+    const mockProps: CreateLessonNoteDialogProps = {
+      studentId: 1,
+      subjects: mockSubjects,
+    };
+
+    wrapper(mockProps);
+
+    const openButton = screen.getByRole("button", { name: /引継ぎ事項を追加/ });
+    expect(openButton).toBeInTheDocument();
+
+    await user.click(openButton);
+    expect(screen.getByText("引継ぎ事項を新規作成")).toBeInTheDocument();
+
+    const submitButton = screen.getByRole("button", { name: "作成" });
+    expect(submitButton).toBeInTheDocument();
+
+    await user.click(submitButton);
+    expect(submitMock).toHaveBeenCalled();
+
+    expect(
+      await screen.findByText("タイトルは50文字以内で入力してください")
+    ).toBeInTheDocument();
+  });
+
+  test("should show loading state when mutation is pending", async () => {
+    const user = userEvent.setup();
+    const submitMock = vi.fn();
+
+    vi.mocked(useLessonNoteForm).mockReturnValue({
+      value: initialLessonFormCreateMockValue,
+      setValue: setValueMock,
+      submit: submitMock,
+      reset: resetMock,
+    });
+
+    vi.mocked(useCreateLessonNoteMutation).mockReturnValue({
+      mutate: mutateMock,
+      isPending: true,
+    } as unknown as ReturnType<typeof useCreateLessonNoteMutation>);
+
+    const mockProps: CreateLessonNoteDialogProps = {
+      studentId: 1,
+      subjects: mockSubjects,
+    };
+
+    wrapper(mockProps);
+
+    const openButton = screen.getByRole("button", { name: /引継ぎ事項を追加/ });
+    expect(openButton).toBeInTheDocument();
+
+    await user.click(openButton);
+    expect(screen.getByText("引継ぎ事項を新規作成")).toBeInTheDocument();
+
+    expect(screen.getByText("引継ぎ事項を作成中...")).toBeInTheDocument();
+  });
+});

--- a/src/features/lessonNotes/test/components/dialog/EditLessonNoteDialog.test.tsx
+++ b/src/features/lessonNotes/test/components/dialog/EditLessonNoteDialog.test.tsx
@@ -1,0 +1,234 @@
+import { Toaster } from "@/components/ui/feedback/Sonner/sonner";
+import { EditLessonNoteDialog } from "@/features/lessonNotes/components/dialog/EditLessonNoteDialog";
+import { useLessonNoteForm } from "@/features/lessonNotes/hooks/useLessonNoteForm";
+import { useUpdateLessonNoteMutation } from "@/features/lessonNotes/mutations/useUpdateLessonNoteMutation";
+import type { LessonNoteEdit } from "@/features/lessonNotes/types/lessonNote";
+import type { EditLessonNoteLocationState } from "@/features/lessonNotes/types/lessonNoteForm";
+import {
+  editLessonNoteFormMockValue,
+  initialLessonFormEditMockValue,
+  lessonNote1,
+  mockSubjects,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    mutations: { retry: false },
+  },
+});
+
+const DashboardPage = () => (
+  <div data-testid="dashboard-page">Dashboard Page</div>
+);
+const NotFoundPage = () => (
+  <div data-testid="notfound-page">Not Found Page</div>
+);
+
+const wrapper = (initialPath: string, state: EditLessonNoteLocationState) => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter
+        initialEntries={[
+          "/dashboard/:studentId", // 戻り先（1件目）
+          {
+            pathname: initialPath,
+            state: {
+              background: state.background,
+              subjects: state.subjects,
+              lessonNote: state.lessonNote,
+            },
+          },
+        ]}
+        initialIndex={1} // ← 2件目（編集）から開始
+      >
+        <Toaster />
+        <Routes>
+          <Route
+            path="/dashboard/:studentId/lesson-notes/:lessonNoteId/edit"
+            element={<EditLessonNoteDialog />}
+          />
+          <Route path="/dashboard/:studentId" element={<DashboardPage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+const successfulRender = () => {
+  const initialPath = "/dashboard/1/lesson-notes/1/edit";
+
+  const state = {
+    background: { pathname: "/dashboard/1" } as Location,
+    subjects: mockSubjects,
+    lessonNote: lessonNote1,
+  };
+  wrapper(initialPath, state);
+};
+
+vi.mock("@/features/lessonNotes/mutations/useUpdateLessonNoteMutation", () => ({
+  useUpdateLessonNoteMutation: vi.fn(),
+}));
+
+vi.mock("@/features/lessonNotes/hooks/useLessonNoteForm", () => ({
+  useLessonNoteForm: vi.fn(),
+}));
+const setValueMock = vi.fn();
+const resetMock = vi.fn();
+const mutateMock = vi.fn();
+
+describe("EditLessonNoteDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+  });
+
+  test("should open and close the dialog correctly and reset the form", async () => {
+    const user = userEvent.setup();
+    const submitMock = vi.fn();
+
+    vi.mocked(useLessonNoteForm).mockReturnValue({
+      value: initialLessonFormEditMockValue,
+      setValue: setValueMock,
+      submit: submitMock,
+      reset: resetMock,
+    });
+
+    vi.mocked(useUpdateLessonNoteMutation).mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateLessonNoteMutation>);
+
+    successfulRender();
+
+    expect(screen.getByText("引継ぎ事項を編集")).toBeInTheDocument();
+
+    const titleInput = screen.getByLabelText(/タイトル/);
+    await user.clear(titleInput);
+    await user.type(titleInput, "タイトルを更新");
+    expect(setValueMock).toHaveBeenCalled();
+
+    // ダイアログを閉じる
+
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    expect(closeButton).toBeInTheDocument();
+    await user.click(closeButton);
+  });
+
+  test("should call mutate when form is submitted", async () => {
+    const user = userEvent.setup();
+
+    const submitMock = vi.fn(
+      (
+        onValid: (data: LessonNoteEdit) => void,
+        onInvalid?: (msgs: string[]) => void
+      ) => {
+        onValid(editLessonNoteFormMockValue);
+        onInvalid?.([]);
+        return true;
+      }
+    );
+
+    vi.mocked(useLessonNoteForm).mockReturnValue({
+      value: editLessonNoteFormMockValue,
+      setValue: setValueMock,
+      submit: submitMock,
+      reset: resetMock,
+    });
+
+    vi.mocked(useUpdateLessonNoteMutation).mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateLessonNoteMutation>);
+
+    successfulRender();
+
+    expect(screen.getByText("引継ぎ事項を編集")).toBeInTheDocument();
+
+    const submitButton = screen.getByRole("button", { name: "更新" });
+    expect(submitButton).toBeInTheDocument();
+
+    await user.click(submitButton);
+    expect(submitMock).toHaveBeenCalled();
+    expect(mutateMock).toHaveBeenCalledWith({
+      ...editLessonNoteFormMockValue,
+      student_id: 1,
+    });
+  });
+
+  test("should display error message when form is invalid", async () => {
+    const user = userEvent.setup();
+
+    const submitMock = vi.fn(
+      (
+        onValid: (data: LessonNoteEdit) => void,
+        onInvalid?: (msgs: string[]) => void
+      ) => {
+        onValid(editLessonNoteFormMockValue);
+        onInvalid?.(["タイトルは50文字以内で入力してください"]);
+        return false;
+      }
+    );
+
+    vi.mocked(useLessonNoteForm).mockReturnValue({
+      value: { ...editLessonNoteFormMockValue, title: "A".repeat(51) },
+      setValue: setValueMock,
+      submit: submitMock,
+      reset: resetMock,
+    });
+
+    vi.mocked(useUpdateLessonNoteMutation).mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateLessonNoteMutation>);
+
+    successfulRender();
+
+    const submitButton = screen.getByRole("button", { name: "更新" });
+    expect(submitButton).toBeInTheDocument();
+
+    await user.click(submitButton);
+    expect(submitMock).toHaveBeenCalled();
+
+    expect(
+      await screen.findByText("タイトルは50文字以内で入力してください")
+    ).toBeInTheDocument();
+  });
+
+  test("should show loading state when mutation is pending", () => {
+    const submitMock = vi.fn();
+
+    vi.mocked(useLessonNoteForm).mockReturnValue({
+      value: initialLessonFormEditMockValue,
+      setValue: setValueMock,
+      submit: submitMock,
+      reset: resetMock,
+    });
+
+    vi.mocked(useUpdateLessonNoteMutation).mockReturnValue({
+      mutate: mutateMock,
+      isPending: true,
+    } as unknown as ReturnType<typeof useUpdateLessonNoteMutation>);
+
+    successfulRender();
+
+    expect(screen.getByText("引継ぎ事項を更新中...")).toBeInTheDocument();
+  });
+
+  test("should navigate to /404 when lessonNoteId or studentId is invalid", () => {
+    const initialPath = "/dashboard/abc/lesson-notes/1/edit"; // studentId が不正
+
+    const state = {
+      background: { pathname: "/dashboard/1" } as Location,
+      subjects: mockSubjects,
+      lessonNote: lessonNote1,
+    };
+    wrapper(initialPath, state);
+    expect(screen.getByTestId("notfound-page")).toBeInTheDocument();
+  });
+});

--- a/src/features/lessonNotes/test/components/drawer/LessonNoteDrawer.test.tsx
+++ b/src/features/lessonNotes/test/components/drawer/LessonNoteDrawer.test.tsx
@@ -1,0 +1,75 @@
+import {
+  LessonNoteDrawer,
+  type LessonNoteDrawerProps,
+} from "@/features/lessonNotes/components/drawer/LessonNoteDrawer";
+import { lessonNote1 } from "@/tests/fixtures/lessonNotes/lessonNotes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { format, parseISO } from "date-fns";
+import { expect } from "vitest";
+import { describe, test } from "vitest";
+
+describe("LessonNoteDrawer", () => {
+  const wrapper = (props: LessonNoteDrawerProps) => {
+    render(<LessonNoteDrawer {...props} />);
+  };
+
+  test("renders correctly", async () => {
+    const user = userEvent.setup();
+    const mockProps: LessonNoteDrawerProps = {
+      lessonNote: {
+        title: lessonNote1.title,
+        description: lessonNote1.description,
+        expire_date: lessonNote1.expire_date,
+        created_by_name: lessonNote1.created_by_name,
+        created_at: lessonNote1.created_at,
+        last_updated_by_name: lessonNote1.last_updated_by_name,
+        updated_at: lessonNote1.updated_at,
+      },
+    };
+
+    const expireDate = format(parseISO(lessonNote1.expire_date), "yyyy/MM/dd");
+    const createdAt = format(parseISO(lessonNote1.created_at), "yyyy/MM/dd");
+    const updatedAt = format(parseISO(lessonNote1.updated_at), "yyyy/MM/dd");
+
+    wrapper({ ...mockProps });
+    const trigger = screen.getByRole("button", { name: lessonNote1.title });
+    await user.click(trigger);
+
+    expect(screen.getByText("引継ぎ事項の詳細情報")).toBeInTheDocument();
+    expect(screen.getByText(lessonNote1.title)).toBeInTheDocument();
+    expect(screen.getByText(lessonNote1.description!)).toBeInTheDocument();
+    expect(screen.getByText(expireDate)).toBeInTheDocument();
+    expect(screen.getByText(lessonNote1.created_by_name)).toBeInTheDocument();
+    expect(screen.getByText(createdAt)).toBeInTheDocument();
+    expect(
+      screen.getByText(lessonNote1.last_updated_by_name!)
+    ).toBeInTheDocument();
+    expect(screen.getByText(updatedAt)).toBeInTheDocument();
+  });
+
+  test("does not render description and last updated info when they are null", async () => {
+    const user = userEvent.setup();
+    const mockProps: LessonNoteDrawerProps = {
+      lessonNote: {
+        title: lessonNote1.title,
+        description: null,
+        expire_date: lessonNote1.expire_date,
+        created_by_name: lessonNote1.created_by_name,
+        created_at: lessonNote1.created_at,
+        last_updated_by_name: null,
+        updated_at: lessonNote1.created_at, // 新規作成の場合、更新日と作成日が同じ
+      },
+    };
+    wrapper({ ...mockProps });
+    const trigger = screen.getByRole("button", { name: lessonNote1.title });
+    await user.click(trigger);
+
+    expect(
+      screen.getByText("詳細の説明は特にありません。")
+    ).toBeInTheDocument();
+    // 最終更新者や更新日がないと--- と表示される
+    const dashes = screen.getAllByText(/^---$/);
+    expect(dashes).toHaveLength(2);
+  });
+});

--- a/src/features/lessonNotes/test/components/lessonNoteForm/LessonNoteForm.test.tsx
+++ b/src/features/lessonNotes/test/components/lessonNoteForm/LessonNoteForm.test.tsx
@@ -1,0 +1,98 @@
+import { LessonNoteForm } from "@/features/lessonNotes/components/LessonNoteForm/LessonNoteForm";
+import type { LessonNoteFormProps } from "@/features/lessonNotes/types/lessonNoteForm";
+import type { Mode } from "@/features/students/types/studentForm";
+import {
+  initialLessonFormCreateMockValue,
+  initialLessonFormEditMockValue,
+  lessonNoteCreateFormMockValue,
+  mockSubjects,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+
+describe("LessonNoteForm", () => {
+  const wrapper = (props: LessonNoteFormProps<Mode>) => {
+    render(<LessonNoteForm {...props} />);
+  };
+
+  test("should render correctly for create mode", () => {
+    const mockProps: LessonNoteFormProps<"create"> = {
+      mode: "create",
+      value: initialLessonFormCreateMockValue,
+      subjects: mockSubjects,
+      onChange: vi.fn(() => {}),
+      onSubmit: vi.fn(() => {}),
+      loading: false,
+    };
+
+    wrapper(mockProps);
+
+    expect(screen.getByLabelText(/科目を選択/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/タイトル/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/詳細説明/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/分類/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/有効期限/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "作成" })).toBeInTheDocument();
+  });
+
+  test("should render correctly for edit mode", () => {
+    const mockProps: LessonNoteFormProps<"edit"> = {
+      mode: "edit",
+      value: initialLessonFormEditMockValue,
+      subjects: mockSubjects,
+      onChange: vi.fn(() => {}),
+      onSubmit: vi.fn(() => {}),
+      loading: false,
+    };
+
+    wrapper(mockProps);
+    expect(screen.getByText(/科目/)).toBeInTheDocument();
+    expect(screen.getByText("英語")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "更新" })).toBeInTheDocument();
+  });
+
+  test("should call onSubmit when submit button is clicked for create mode", async () => {
+    const user = userEvent.setup();
+    const mockProps: LessonNoteFormProps<"create"> = {
+      mode: "create",
+      value: lessonNoteCreateFormMockValue,
+      subjects: mockSubjects,
+      onChange: vi.fn(() => {}),
+      onSubmit: vi.fn(() => {}),
+      loading: false,
+    };
+
+    wrapper(mockProps);
+
+    const createButton = screen.getByRole("button", { name: "作成" });
+    expect(createButton).toBeInTheDocument();
+
+    await user.click(createButton);
+    expect(mockProps.onSubmit).toHaveBeenCalledWith(
+      lessonNoteCreateFormMockValue
+    );
+  });
+
+  test("should call onSubmit when submit button is clicked for edit mode", async () => {
+    const user = userEvent.setup();
+    const mockProps: LessonNoteFormProps<"edit"> = {
+      mode: "edit",
+      value: initialLessonFormEditMockValue,
+      subjects: mockSubjects,
+      onChange: vi.fn(() => {}),
+      onSubmit: vi.fn(() => {}),
+      loading: false,
+    };
+
+    wrapper(mockProps);
+
+    const editButton = screen.getByRole("button", { name: "更新" });
+    expect(editButton).toBeInTheDocument();
+
+    await user.click(editButton);
+    expect(mockProps.onSubmit).toHaveBeenCalledWith(
+      initialLessonFormEditMockValue
+    );
+  });
+});

--- a/src/features/lessonNotes/test/components/lessonNoteForm/parts/DescriptionField.test.tsx
+++ b/src/features/lessonNotes/test/components/lessonNoteForm/parts/DescriptionField.test.tsx
@@ -1,0 +1,51 @@
+import {
+  DescriptionField,
+  type DescriptionFieldProps,
+} from "@/features/lessonNotes/components/LessonNoteForm/parts/DescriptionField";
+import type { Mode } from "@/features/students/types/studentForm";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+
+describe("DescriptionField", () => {
+  const wrapper = (props: DescriptionFieldProps<Mode>) => {
+    render(<DescriptionField {...props} />);
+  };
+
+  test("should render correctly when mode is create", async () => {
+    const user = userEvent.setup();
+    const mockProps: DescriptionFieldProps<"create"> = {
+      description: null,
+      onChange: vi.fn(() => () => {}),
+    };
+
+    wrapper(mockProps);
+    // 必須の星があるので正規表現で取得
+    const descriptionInput = screen.getByLabelText(/詳細説明/);
+    expect(descriptionInput).toBeInTheDocument();
+    expect(descriptionInput).toHaveValue("");
+
+    // 入力操作
+    await user.type(descriptionInput, "新規作成");
+    expect(mockProps.onChange).toHaveBeenCalledWith("description");
+  });
+  test("should render correctly when mode is edit", async () => {
+    const user = userEvent.setup();
+    const mockProps: DescriptionFieldProps<"edit"> = {
+      description: "編集時の詳細説明の初期値",
+      onChange: vi.fn(() => () => {}),
+    };
+
+    wrapper(mockProps);
+    // 必須の星があるので正規表現で取得
+    const descriptionInput = screen.getByLabelText(/詳細説明/);
+    expect(descriptionInput).toBeInTheDocument();
+    expect(descriptionInput).toHaveValue("編集時の詳細説明の初期値");
+
+    // 入力操作
+    await user.clear(descriptionInput);
+    await user.type(descriptionInput, "更新");
+    expect(mockProps.onChange).toHaveBeenCalledWith("description");
+  });
+});

--- a/src/features/lessonNotes/test/components/lessonNoteForm/parts/ExpireDatePicker.test.tsx
+++ b/src/features/lessonNotes/test/components/lessonNoteForm/parts/ExpireDatePicker.test.tsx
@@ -1,0 +1,77 @@
+import {
+  ExpireDatePicker,
+  type ExpireDatePickerProps,
+} from "@/features/lessonNotes/components/LessonNoteForm/parts/ExpireDatePicker";
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { format } from "date-fns";
+import { describe, expect, test, vi } from "vitest";
+
+describe("ExpireDatePicker", () => {
+  const wrapper = (props: ExpireDatePickerProps) => {
+    render(<ExpireDatePicker {...props} />);
+  };
+
+  test("should render correctly when expireDate is undefined", async () => {
+    const user = userEvent.setup();
+    const mockProps: ExpireDatePickerProps = {
+      expireDate: undefined,
+      onChange: vi.fn(() => {}),
+    };
+
+    wrapper(mockProps);
+
+    const dayButton = screen.getByRole("button", { name: /有効期限/ });
+    expect(dayButton).toBeInTheDocument();
+
+    // カレンダー表示
+    await user.click(dayButton);
+    const calendar = screen.getByRole("dialog");
+    expect(calendar).toBeInTheDocument();
+
+    const isoToday = format(new Date(), "yyyy-MM-dd");
+    const dayCell = calendar.querySelector<HTMLTableCellElement>(
+      `[data-day="${isoToday}"]`
+    );
+    expect(dayCell).toBeTruthy();
+
+    await user.click(within(dayCell!).getByRole("button"));
+
+    expect(mockProps.onChange).toHaveBeenCalledWith(isoToday);
+    expect(calendar).not.toBeInTheDocument();
+  });
+
+  test("should render correctly when expireDate is given", async () => {
+    const user = userEvent.setup();
+    const todayISOString = format(new Date(), "yyyy-MM-dd");
+    const tomorrowISOString = format(
+      new Date(Date.now() + 24 * 60 * 60 * 1000),
+      "yyyy-MM-dd"
+    );
+    const mockProps: ExpireDatePickerProps = {
+      expireDate: todayISOString,
+      onChange: vi.fn(() => {}),
+    };
+
+    wrapper(mockProps);
+
+    const dayButton = screen.getByRole("button", { name: /有効期限/ });
+    expect(dayButton).toBeInTheDocument();
+
+    // カレンダー表示
+    await user.click(dayButton);
+    const calendar = screen.getByRole("dialog");
+    expect(calendar).toBeInTheDocument();
+
+    const dayCell = calendar.querySelector<HTMLTableCellElement>(
+      `[data-day="${tomorrowISOString}"]`
+    );
+    expect(dayCell).toBeTruthy();
+
+    await user.click(within(dayCell!).getByRole("button"));
+
+    expect(mockProps.onChange).toHaveBeenCalledWith(tomorrowISOString);
+    expect(calendar).not.toBeInTheDocument();
+  });
+});

--- a/src/features/lessonNotes/test/components/lessonNoteForm/parts/NoteTypeSelect.test.tsx
+++ b/src/features/lessonNotes/test/components/lessonNoteForm/parts/NoteTypeSelect.test.tsx
@@ -1,0 +1,50 @@
+import {
+  NoteTypeSelect,
+  type NoteTypeSelectProps,
+} from "@/features/lessonNotes/components/LessonNoteForm/parts/NoteTypeSelect";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+
+describe("NoteTypeSelect", () => {
+  const wrapper = (props: NoteTypeSelectProps) => {
+    render(<NoteTypeSelect {...props} />);
+  };
+
+  test("should render correctly when noteType is undefined", async () => {
+    const user = userEvent.setup();
+    const mockProps: NoteTypeSelectProps = {
+      noteType: undefined,
+      onChange: vi.fn(() => {}),
+    };
+
+    wrapper(mockProps);
+
+    const selectTrigger = screen.getByLabelText(/分類を選択/);
+    expect(selectTrigger).toBeInTheDocument();
+    await user.click(selectTrigger);
+
+    const option = screen.getByRole("option", { name: "宿題" });
+    await user.click(option);
+    expect(mockProps.onChange).toHaveBeenCalledWith("homework");
+  });
+
+  test("should render correctly when noteType is defined", async () => {
+    const user = userEvent.setup();
+    const mockProps: NoteTypeSelectProps = {
+      noteType: "lesson",
+      onChange: vi.fn(() => {}),
+    };
+
+    wrapper(mockProps);
+
+    const selectTrigger = screen.getByLabelText(/分類を選択/);
+    expect(selectTrigger).toBeInTheDocument();
+    expect(screen.getByText("授業")).toBeInTheDocument();
+    await user.click(selectTrigger);
+
+    const option = screen.getByRole("option", { name: "宿題" });
+    await user.click(option);
+    expect(mockProps.onChange).toHaveBeenCalledWith("homework");
+  });
+});

--- a/src/features/lessonNotes/test/components/lessonNoteForm/parts/SubjectField.test.tsx
+++ b/src/features/lessonNotes/test/components/lessonNoteForm/parts/SubjectField.test.tsx
@@ -1,0 +1,41 @@
+import {
+  SubjectField,
+  type SubjectFieldProps,
+} from "@/features/lessonNotes/components/LessonNoteForm/parts/SubjectField";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+const wrapper = (props: SubjectFieldProps) => {
+  render(<SubjectField {...props} />);
+};
+
+describe("SubjectField", () => {
+  test("renders correctly", () => {
+    const mockProps: SubjectFieldProps = {
+      subject_id: 1, // 英語
+      subjects: [
+        { id: 1, name: "english" },
+        { id: 3, name: "mathematics" },
+      ],
+    };
+
+    wrapper(mockProps);
+
+    expect(screen.getByText("科目")).toBeInTheDocument();
+    expect(screen.getByText("英語")).toBeInTheDocument();
+  });
+
+  test("renders '不明な科目' when subject is not found", () => {
+    const mockProps: SubjectFieldProps = {
+      subject_id: 999, // 存在しないID
+      subjects: [
+        { id: 1, name: "english" },
+        { id: 3, name: "mathematics" },
+      ],
+    };
+
+    wrapper(mockProps);
+
+    expect(screen.getByText("不明な科目")).toBeInTheDocument();
+  });
+});

--- a/src/features/lessonNotes/test/components/lessonNoteForm/parts/SubjectSelect.test.tsx
+++ b/src/features/lessonNotes/test/components/lessonNoteForm/parts/SubjectSelect.test.tsx
@@ -1,0 +1,34 @@
+import {
+  SubjectSelect,
+  type SubjectSelectProps,
+} from "@/features/lessonNotes/components/LessonNoteForm/parts/SubjectSelect";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+
+describe("SubjectSelect", () => {
+  const wrapper = (props: SubjectSelectProps) => {
+    render(<SubjectSelect {...props} />);
+  };
+
+  test("should render correctly when subjectId is provided", async () => {
+    const user = userEvent.setup();
+    const mockProps: SubjectSelectProps = {
+      subjects: [
+        { id: 1, name: "english" },
+        { id: 2, name: "mathematics" },
+      ],
+      onChange: vi.fn(() => {}),
+    };
+
+    wrapper(mockProps);
+
+    const selectTrigger = screen.getByLabelText(/科目を選択/);
+    expect(selectTrigger).toBeInTheDocument();
+    await user.click(selectTrigger);
+
+    const englishOption = screen.getByRole("option", { name: "英語" });
+    await user.click(englishOption);
+    expect(mockProps.onChange).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/features/lessonNotes/test/components/lessonNoteForm/parts/TitleField.test.tsx
+++ b/src/features/lessonNotes/test/components/lessonNoteForm/parts/TitleField.test.tsx
@@ -1,0 +1,51 @@
+import {
+  TitleField,
+  type TitleFieldProps,
+} from "@/features/lessonNotes/components/LessonNoteForm/parts/TitleField";
+import type { Mode } from "@/features/students/types/studentForm";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+
+describe("TitleField", () => {
+  const wrapper = (props: TitleFieldProps<Mode>) => {
+    render(<TitleField {...props} />);
+  };
+
+  test("should render correctly when mode is create", async () => {
+    const user = userEvent.setup();
+    const mockProps: TitleFieldProps<"create"> = {
+      title: "",
+      onChange: vi.fn(() => () => {}),
+    };
+
+    wrapper(mockProps);
+    // 必須の星があるので正規表現で取得
+    const titleInput = screen.getByLabelText(/タイトル/);
+    expect(titleInput).toBeInTheDocument();
+    expect(titleInput).toHaveValue("");
+
+    // 入力操作
+    await user.type(titleInput, "新規作成");
+    expect(mockProps.onChange).toHaveBeenCalledWith("title");
+  });
+  test("should render correctly when mode is edit", async () => {
+    const user = userEvent.setup();
+    const mockProps: TitleFieldProps<"edit"> = {
+      title: "英語の宿題",
+      onChange: vi.fn(() => () => {}),
+    };
+
+    wrapper(mockProps);
+    // 必須の星があるので正規表現で取得
+    const titleInput = screen.getByLabelText(/タイトル/);
+    expect(titleInput).toBeInTheDocument();
+    expect(titleInput).toHaveValue("英語の宿題");
+
+    // 入力操作
+    await user.clear(titleInput);
+    await user.type(titleInput, "更新");
+    expect(mockProps.onChange).toHaveBeenCalledWith("title");
+  });
+});

--- a/src/features/lessonNotes/test/hooks/useLessonNoteForm.test.ts
+++ b/src/features/lessonNotes/test/hooks/useLessonNoteForm.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useLessonNoteForm } from "../../hooks/useLessonNoteForm";
+import { LessonNoteInitialValues } from "../../constants/lessonNoteForm";
+import {
+  initialLessonFormEditMockValue,
+  lessonNoteCreateFormMockValue,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+
+describe("useLessonNoteForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("should initialize form state correctly for create mode", () => {
+    const { result } = renderHook(() => useLessonNoteForm("create"));
+
+    const { value, setValue, submit, reset } = result.current;
+
+    expect(value).toEqual(LessonNoteInitialValues);
+    expect(typeof setValue).toBe("function");
+    expect(typeof submit).toBe("function");
+    expect(typeof reset).toBe("function");
+  });
+  test("should initialize form state correctly for edit mode with initial data", () => {
+    const initialData = {
+      ...initialLessonFormEditMockValue,
+    };
+
+    const { result } = renderHook(() => useLessonNoteForm("edit", initialData));
+
+    const { value } = result.current;
+    expect(value).toEqual(initialData);
+  });
+
+  test("submit should validate and return correct payload for create mode", () => {
+    const { result } = renderHook(() => useLessonNoteForm("create"));
+
+    act(() => {
+      result.current.setValue(lessonNoteCreateFormMockValue);
+    });
+
+    const onValidSpy = vi.fn();
+    const onInvalidSpy = vi.fn();
+
+    const submitResult = result.current.submit(onValidSpy, onInvalidSpy);
+    expect(submitResult).toBe(true);
+    expect(onValidSpy).toHaveBeenCalledWith(lessonNoteCreateFormMockValue);
+    expect(onInvalidSpy).not.toHaveBeenCalled();
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.value).toEqual(LessonNoteInitialValues);
+  });
+
+  test("submit should call onInvalid for invalid data for create mode", () => {
+    const { result } = renderHook(() => useLessonNoteForm("create"));
+
+    const overTitle = "a".repeat(51); // titleの最大長は50
+    act(() => {
+      result.current.setValue({
+        ...lessonNoteCreateFormMockValue,
+        title: overTitle,
+      });
+    });
+
+    const onValidSpy = vi.fn();
+    const onInvalidSpy = vi.fn();
+
+    const submitResult = result.current.submit(onValidSpy, onInvalidSpy);
+    expect(submitResult).toBe(false);
+    expect(onValidSpy).not.toHaveBeenCalled();
+    expect(onInvalidSpy).toHaveBeenCalledWith([
+      "タイトルは50文字以内で入力してください",
+    ]);
+  });
+
+  test("submit should validate and return correct payload for edit mode", () => {
+    const initialData = {
+      ...initialLessonFormEditMockValue,
+    };
+    const { result } = renderHook(() => useLessonNoteForm("edit", initialData));
+
+    act(() => {
+      result.current.setValue(initialLessonFormEditMockValue);
+    });
+
+    const onValidSpy = vi.fn();
+    const onInvalidSpy = vi.fn();
+
+    const submitResult = result.current.submit(onValidSpy, onInvalidSpy);
+    expect(submitResult).toBe(true);
+    expect(onValidSpy).toHaveBeenCalledWith({
+      ...initialLessonFormEditMockValue,
+    });
+    expect(onInvalidSpy).not.toHaveBeenCalled();
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.value).toEqual(initialData);
+    expect(result.current.value.id).toBe(initialData.id);
+  });
+});

--- a/src/features/lessonNotes/test/mutations/useCreateLessonNoteMutation.test.tsx
+++ b/src/features/lessonNotes/test/mutations/useCreateLessonNoteMutation.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+import {
+  createLessonNotePayload,
+  createResponseLessonNoteMock,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+import { CreateLessonNote } from "../../api/lessonNoteCreateApi";
+import { useCreateLessonNoteMutation } from "../../mutations/useCreateLessonNoteMutation";
+import { lessonNoteKeys } from "../../key";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    mutations: { retry: false },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+vi.mock("../../api/lessonNoteCreateApi", () => ({
+  CreateLessonNote: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+describe("useCreateLessonNoteMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+  });
+  test("should create lesson note successfully", async () => {
+    const mockResponseData = {
+      ...createResponseLessonNoteMock,
+    };
+
+    const mockPayload = {
+      ...createLessonNotePayload,
+    };
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+
+    vi.mocked(CreateLessonNote).mockResolvedValueOnce(mockResponseData);
+    vi.mocked(toast.success).mockResolvedValueOnce("授業引継ぎを作成しました");
+
+    const { result } = renderHook(() => useCreateLessonNoteMutation(), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      result.current.mutate(mockPayload);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: lessonNoteKeys.lists(),
+    });
+
+    const detailKey = lessonNoteKeys.detail(mockResponseData.id);
+    expect(setQueryDataSpy).toHaveBeenCalledWith(detailKey, mockResponseData);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.data).toEqual(mockResponseData);
+    expect(toast.success).toHaveBeenCalledWith("授業引継ぎを作成しました");
+  });
+
+  test("should handle error state", async () => {
+    const mockPayload = {
+      ...createLessonNotePayload,
+    };
+    const mockError = new Error("Failed to create lesson note");
+
+    vi.mocked(CreateLessonNote).mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useCreateLessonNoteMutation(), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      result.current.mutate(mockPayload);
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error).toBe(mockError);
+    expect(toast.error).toHaveBeenCalled();
+  });
+});

--- a/src/features/lessonNotes/test/mutations/useUpdateLessonNoteMutation.test.tsx
+++ b/src/features/lessonNotes/test/mutations/useUpdateLessonNoteMutation.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+import {
+  editLessonNotePayload,
+  editResponseLessonNoteMock,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+import { UpdateLessonNote } from "../../api/lessonNoteUpdateApi";
+import { useUpdateLessonNoteMutation } from "../../mutations/useUpdateLessonNoteMutation";
+import { lessonNoteKeys } from "../../key";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    mutations: { retry: false },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+vi.mock("../../api/lessonNoteUpdateApi", () => ({
+  UpdateLessonNote: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+describe("useUpdateLessonNoteMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+  });
+  test("should update lesson note successfully", async () => {
+    const mockResponseData = {
+      ...editResponseLessonNoteMock,
+    };
+
+    const mockPayload = {
+      ...editLessonNotePayload,
+    };
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+
+    vi.mocked(UpdateLessonNote).mockResolvedValueOnce(mockResponseData);
+    vi.mocked(toast.success).mockResolvedValueOnce("引継ぎ事項を更新しました");
+
+    const { result } = renderHook(() => useUpdateLessonNoteMutation(), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      result.current.mutate(mockPayload);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: lessonNoteKeys.lists(),
+    });
+
+    const detailKey = lessonNoteKeys.detail(mockResponseData.id);
+    expect(setQueryDataSpy).toHaveBeenCalledWith(detailKey, mockResponseData);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.data).toEqual(mockResponseData);
+    expect(toast.success).toHaveBeenCalledWith("引継ぎ事項を更新しました");
+  });
+
+  test("should handle error state", async () => {
+    const mockPayload = {
+      ...editLessonNotePayload,
+    };
+    const mockError = new Error("Failed to update lesson note");
+
+    vi.mocked(UpdateLessonNote).mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useUpdateLessonNoteMutation(), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      result.current.mutate(mockPayload);
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error).toBe(mockError);
+    expect(toast.error).toHaveBeenCalled();
+  });
+});

--- a/src/features/lessonNotes/test/queries/useLessonNotesQuery.test.tsx
+++ b/src/features/lessonNotes/test/queries/useLessonNotesQuery.test.tsx
@@ -1,0 +1,101 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { LessonNoteListFilters } from "../../key";
+import {
+  LessonNotesMeta,
+  lessonNotesMock,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+import type { FetchLessonNotesResponse } from "../../types/lessonNote";
+import { FetchLessonNotes } from "../../api/lessonNotesApi";
+import { useLessonNotesQuery } from "../../queries/useLessonNotesQuery";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+vi.mock("../../api/lessonNotesApi", () => ({
+  FetchLessonNotes: vi.fn(),
+}));
+
+describe("useLessonNotesQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+  });
+  test("should fetch lesson notes successfully", async () => {
+    const mockFilters: LessonNoteListFilters = {
+      student_id: 1, //student1
+      subject_id: 1, // 英語
+      searchKeyword: undefined,
+      page: 1,
+      perPage: 10,
+    };
+    const mockResponse = {
+      lesson_notes: lessonNotesMock,
+      meta: LessonNotesMeta,
+    } as FetchLessonNotesResponse;
+
+    vi.mocked(FetchLessonNotes).mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() => useLessonNotesQuery(mockFilters), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockResponse);
+  });
+
+  test("should not fetch lesson notes when disabled", async () => {
+    const mockFilters: LessonNoteListFilters = {
+      student_id: 1, //student1
+      subject_id: 1, // 英語
+      searchKeyword: undefined,
+      page: 1,
+      perPage: 10,
+    };
+
+    const { result } = renderHook(
+      () => useLessonNotesQuery(mockFilters, { enabled: false }),
+      {
+        wrapper,
+      }
+    );
+    expect(result.current.data).toBeUndefined();
+    expect(FetchLessonNotes).not.toHaveBeenCalled();
+  });
+
+  test("should handle error state", async () => {
+    const mockFilters: LessonNoteListFilters = {
+      student_id: 1, //student1
+      subject_id: 1, // 英語
+      searchKeyword: undefined,
+      page: 1,
+      perPage: 10,
+    };
+    const mockError = new Error("Failed to fetch lesson notes");
+
+    vi.mocked(FetchLessonNotes).mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useLessonNotesQuery(mockFilters), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(mockError);
+  });
+});

--- a/src/features/lessonNotes/test/utils/columnsUtils.test.tsx
+++ b/src/features/lessonNotes/test/utils/columnsUtils.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { columnsUtils } from "../../utils/columnsUtils";
+import { addDays, format } from "date-fns";
+import { render, screen } from "@testing-library/react";
+
+describe("columnsUtils", () => {
+  test("formatExpireDate renders correctly", () => {
+    const { formatExpireDate } = columnsUtils();
+    const tomorrow = addDays(new Date(), 1);
+    const isoString = format(tomorrow, "yyyy-MM-dd");
+    const displayDate = format(tomorrow, "yyyy/MM/dd");
+    render(<>{formatExpireDate(isoString)}</>);
+    expect(screen.getByText(displayDate)).toBeInTheDocument();
+  });
+  test("formatExpireDate renders expired badge when the date is past", () => {
+    const { formatExpireDate } = columnsUtils();
+    const yesterday = addDays(new Date(), -1);
+    const isoString = format(yesterday, "yyyy-MM-dd");
+    render(<>{formatExpireDate(isoString)}</>);
+    expect(screen.getByText("期限切れ")).toBeInTheDocument();
+  });
+  test("formatExpireDate does not render when iso string is empty", () => {
+    const { formatExpireDate } = columnsUtils();
+    render(<>{formatExpireDate("")}</>);
+    expect(screen.getByText("無効な日付")).toBeInTheDocument();
+  });
+
+  test("formatNoteType renders correctly", () => {
+    const { formatNoteType } = columnsUtils();
+    render(<>{formatNoteType("lesson")}</>);
+    expect(screen.getByText("授業")).toBeInTheDocument();
+    expect(screen.getByTestId("lesson-note-icon-lesson")).toBeInTheDocument();
+  });
+});

--- a/src/features/lessonNotes/test/utils/formatEditValue.test.ts
+++ b/src/features/lessonNotes/test/utils/formatEditValue.test.ts
@@ -1,0 +1,19 @@
+import { lessonNote1 } from "@/tests/fixtures/lessonNotes/lessonNotes";
+import { describe, expect, test } from "vitest";
+import type { lessonNoteType } from "../../types/lessonNote";
+import { formatEditValue } from "../../utils/formatEditValue";
+
+describe("formatEditValue", () => {
+  test("should format lesson note correctly", () => {
+    const mockProps: lessonNoteType = lessonNote1;
+    const result = formatEditValue(mockProps);
+    expect(result).toEqual({
+      id: 1,
+      subject_id: 1,
+      title: lessonNote1.title,
+      description: lessonNote1.description,
+      note_type: lessonNote1.note_type,
+      expire_date: lessonNote1.expire_date,
+    });
+  });
+});

--- a/src/features/lessonNotes/test/utils/lessonNoteFormHandlers.test.tsx
+++ b/src/features/lessonNotes/test/utils/lessonNoteFormHandlers.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { lessonNoteFormHandlers } from "../../utils/lessonNoteFormHandlers";
+import type { LessonNoteFormValuesByMode } from "../../types/lessonNoteForm";
+import type { Mode } from "@/features/students/types/studentForm";
+import {
+  initialLessonFormCreateMockValue,
+  initialLessonFormEditMockValue,
+} from "@/tests/fixtures/lessonNotes/lessonNotes";
+
+const makeOnChangeHarness = <M extends Mode>(
+  initial: LessonNoteFormValuesByMode<M>
+) => {
+  // initial をクローンして state として保持(initial は変更されない)
+  let state = structuredClone(initial);
+  // update の関数があればそれを使用する
+  const onChange = (
+    updater:
+      | LessonNoteFormValuesByMode<M>
+      | ((prev: LessonNoteFormValuesByMode<M>) => LessonNoteFormValuesByMode<M>)
+  ) => {
+    state = typeof updater === "function" ? updater(state) : updater;
+  };
+  return { onChange, get: () => state };
+};
+
+describe("lessonNoteFormHandlers", () => {
+  test("handleInputChange updates the input field value when mode is create", async () => {
+    const h = makeOnChangeHarness<"create">(initialLessonFormCreateMockValue);
+    const user = userEvent.setup();
+    const { handleInputChange } = lessonNoteFormHandlers<"create">(h.onChange);
+
+    render(
+      <input onChange={handleInputChange("title")} data-testid="title-input" />
+    );
+    const input = screen.getByTestId("title-input");
+    await user.type(input, "新しいタイトル");
+
+    expect(h.get().title).toBe("新しいタイトル");
+  });
+
+  test("handleInputChange updates the input field value when mode is edit", async () => {
+    const h = makeOnChangeHarness<"edit">(initialLessonFormEditMockValue);
+    const user = userEvent.setup();
+    const { handleInputChange } = lessonNoteFormHandlers<"edit">(h.onChange);
+
+    render(
+      <input onChange={handleInputChange("title")} data-testid="title-input" />
+    );
+    const input = screen.getByTestId("title-input");
+    await user.clear(input);
+    await user.type(input, "新しいタイトル");
+
+    expect(h.get().title).toBe("新しいタイトル");
+  });
+
+  test("handleTextAreaChange updates the textarea field value when mode is create", async () => {
+    const h = makeOnChangeHarness<"create">(initialLessonFormCreateMockValue);
+    const user = userEvent.setup();
+    const { handleTextAreaChange } = lessonNoteFormHandlers<"create">(
+      h.onChange
+    );
+
+    render(
+      <textarea
+        onChange={handleTextAreaChange("description")}
+        data-testid="description-textarea"
+      />
+    );
+    const textarea = screen.getByTestId("description-textarea");
+    await user.type(textarea, "新しい詳細説明");
+
+    expect(h.get().description).toBe("新しい詳細説明");
+  });
+
+  test("handleTextAreaChange updates the textarea field value when mode is edit", async () => {
+    const h = makeOnChangeHarness<"edit">(initialLessonFormEditMockValue);
+    const user = userEvent.setup();
+    const { handleTextAreaChange } = lessonNoteFormHandlers<"edit">(h.onChange);
+
+    render(
+      <textarea
+        onChange={handleTextAreaChange("description")}
+        data-testid="description-textarea"
+      />
+    );
+    const textarea = screen.getByTestId("description-textarea");
+    await user.clear(textarea);
+    await user.type(textarea, "新しい詳細説明");
+
+    expect(h.get().description).toBe("新しい詳細説明");
+  });
+
+  test("handleSelectChange updates the select field value when mode is create", () => {
+    const h = makeOnChangeHarness<"create">(initialLessonFormCreateMockValue);
+    const { handleSelectChange } = lessonNoteFormHandlers<"create">(h.onChange);
+
+    handleSelectChange("note_type")("lesson");
+    expect(h.get().note_type).toBe("lesson");
+  });
+
+  test("handleSelectChange updates the select field value when mode is edit", () => {
+    const h = makeOnChangeHarness<"edit">(initialLessonFormEditMockValue);
+    const { handleSelectChange } = lessonNoteFormHandlers<"edit">(h.onChange);
+
+    handleSelectChange("subject_id")(2);
+    expect(h.get().subject_id).toBe(2);
+  });
+});

--- a/src/features/lessonNotes/test/utils/lessonNoteFormTransforms.test.ts
+++ b/src/features/lessonNotes/test/utils/lessonNoteFormTransforms.test.ts
@@ -1,0 +1,44 @@
+import { lessonNoteCreateFormMockValue } from "@/tests/fixtures/lessonNotes/lessonNotes";
+import { describe, expect, test } from "vitest";
+import { normalizeLessonNotePayload } from "../../utils/lessonNoteFormTransforms";
+
+describe("lessonNoteFormTransforms", () => {
+  test("transforms work correctly when trimming whitespace", () => {
+    const mockProps = {
+      ...lessonNoteCreateFormMockValue,
+      description: "  前後にスペース  ",
+    };
+
+    const result = normalizeLessonNotePayload(mockProps);
+    expect(result).toEqual({
+      ...lessonNoteCreateFormMockValue,
+      description: "前後にスペース",
+    });
+  });
+
+  test("transforms work correctly when description is only whitespace", () => {
+    const mockProps = {
+      ...lessonNoteCreateFormMockValue,
+      description: "     ",
+    };
+
+    const result = normalizeLessonNotePayload(mockProps);
+    expect(result).toEqual({
+      ...lessonNoteCreateFormMockValue,
+      description: null,
+    });
+  });
+
+  test("transforms work correctly when description is empty string", () => {
+    const mockProps = {
+      ...lessonNoteCreateFormMockValue,
+      description: "",
+    };
+
+    const result = normalizeLessonNotePayload(mockProps);
+    expect(result).toEqual({
+      ...lessonNoteCreateFormMockValue,
+      description: null,
+    });
+  });
+});

--- a/src/features/studentDashboard/components/dashboard/StudentSiteHeader.tsx
+++ b/src/features/studentDashboard/components/dashboard/StudentSiteHeader.tsx
@@ -5,7 +5,7 @@ import { useIsMobile } from "@/hooks/useMobile";
 import { formatGrade } from "@/utils/formatGrade";
 import { StudentSiteHoverCard } from "./StudentSiteHoverCard";
 
-type SiteHeaderProps = {
+export type SiteHeaderProps = {
   school: string | null;
   data: StudentDetail;
 };

--- a/src/features/studentDashboard/components/dashboard/StudentSiteHoverCard.tsx
+++ b/src/features/studentDashboard/components/dashboard/StudentSiteHoverCard.tsx
@@ -5,7 +5,7 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/layout/HoverCard/hover-card";
 
-type HoverCardGenericProps = {
+export type HoverCardGenericProps = {
   name: string;
   grade: string;
   desiredSchool: string;

--- a/src/features/studentDashboard/test/api/fetchStudentApi.test.ts
+++ b/src/features/studentDashboard/test/api/fetchStudentApi.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { api } from "@/lib/api";
+import { fetchStudent } from "../../api/fetchStudentApi";
+import { studentDetailMock } from "@/tests/fixtures/students/students";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+const STUDENT_ID = 1;
+describe("fetchStudentApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("fetchStudent", async () => {
+    const mockResponse = {
+      data: {
+        ...studentDetailMock,
+      },
+    };
+
+    vi.mocked(api.get).mockResolvedValueOnce(mockResponse);
+
+    const result = await fetchStudent(STUDENT_ID);
+    expect(result).toEqual({
+      ...studentDetailMock,
+    });
+  });
+
+  test("fetchStudent - handles API error", async () => {
+    const apiError = new Error("API Error");
+    vi.mocked(api.get).mockRejectedValueOnce(apiError);
+
+    await expect(fetchStudent(STUDENT_ID)).rejects.toThrow("API Error");
+  });
+
+  test("fetchStudent - handles invalid response data", async () => {
+    const invalidResponse = {
+      data: {
+        id: "invalid_id", // 本来は数値であるべき
+      },
+    };
+
+    vi.mocked(api.get).mockResolvedValueOnce(invalidResponse);
+
+    // Zodエラーがスローされることを確認
+    await expect(fetchStudent(1)).rejects.toThrow();
+  });
+});

--- a/src/features/studentDashboard/test/components/dashboard/StudentSiteHeader.test.tsx
+++ b/src/features/studentDashboard/test/components/dashboard/StudentSiteHeader.test.tsx
@@ -1,0 +1,50 @@
+import { SidebarProvider } from "@/components/ui/layout/Sidebar/sidebar";
+import {
+  StudentSiteHeader,
+  type SiteHeaderProps,
+} from "@/features/studentDashboard/components/dashboard/StudentSiteHeader";
+
+import { useIsMobile } from "@/hooks/useMobile";
+import { studentDetailMock } from "@/tests/fixtures/students/students";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+const wrapper = (props: SiteHeaderProps) => {
+  render(
+    <SidebarProvider>
+      <StudentSiteHeader {...props} />
+    </SidebarProvider>
+  );
+};
+
+vi.mock("@/hooks/useMobile", () => ({
+  useIsMobile: vi.fn(),
+}));
+
+describe("StudentSiteHeader", () => {
+  test("renders correctly", () => {
+    const mockProps: SiteHeaderProps = {
+      school: "Test School",
+      data: studentDetailMock,
+    };
+    vi.mocked(useIsMobile).mockReturnValue(false);
+    wrapper(mockProps);
+
+    expect(screen.getByText("高校3年")).toBeInTheDocument();
+    expect(screen.getByText("mockStudent One")).toBeInTheDocument();
+    expect(screen.getByText("Stanford university")).toBeInTheDocument();
+    expect(screen.getByText("Test School")).toBeInTheDocument();
+  });
+
+  test("renders correctly on mobile", () => {
+    const mockProps: SiteHeaderProps = {
+      school: "Test School",
+      data: studentDetailMock,
+    };
+    vi.mocked(useIsMobile).mockReturnValue(true);
+    wrapper(mockProps);
+
+    expect(screen.getByText("mockStudent One")).toBeInTheDocument();
+    expect(screen.queryByText("Test School")).toBeInTheDocument();
+  });
+});

--- a/src/features/studentDashboard/test/components/dashboard/StudentSiteHoverCard.test.tsx
+++ b/src/features/studentDashboard/test/components/dashboard/StudentSiteHoverCard.test.tsx
@@ -1,0 +1,31 @@
+import {
+  StudentSiteHoverCard,
+  type HoverCardGenericProps,
+} from "@/features/studentDashboard/components/dashboard/StudentSiteHoverCard";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+
+const wrapper = (props: HoverCardGenericProps) => {
+  render(<StudentSiteHoverCard {...props} />);
+};
+
+describe("StudentSiteHoverCard", () => {
+  test("renders correctly", async () => {
+    const user = userEvent.setup();
+    const mockProps: HoverCardGenericProps = {
+      name: "mockStudent One",
+      grade: "高校3年",
+      desiredSchool: "Stanford university",
+    };
+    wrapper(mockProps);
+
+    const trigger = screen.getByRole("button", {
+      name: /氏名 mockStudent One/i,
+    });
+    await user.hover(trigger);
+
+    expect(await screen.findByText(mockProps.grade)).toBeInTheDocument();
+    expect(screen.getByText(mockProps.desiredSchool)).toBeInTheDocument();
+  });
+});

--- a/src/features/studentDashboard/test/components/getStudentDashboardData.test.ts
+++ b/src/features/studentDashboard/test/components/getStudentDashboardData.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { getStudentDashboardData } from "../components/getStudentDashboardData";
+import { getStudentDashboardData } from "../../components/getStudentDashboardData";
 
 describe("getStudentDashboardData", () => {
   test("navMain has 2 items for admin", () => {

--- a/src/features/studentDashboard/test/queries/useStudentDetailQuery.test.tsx
+++ b/src/features/studentDashboard/test/queries/useStudentDetailQuery.test.tsx
@@ -1,0 +1,63 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { studentDetailMock } from "../../../../tests/fixtures/students/students";
+import type { StudentDetail } from "../../type/studentDashboard";
+import { fetchStudent } from "../../api/fetchStudentApi";
+import { useStudentDetailQuery } from "../../queries/useStudentDetailQuery";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+vi.mock("../../api/fetchStudentApi", () => ({
+  fetchStudent: vi.fn(),
+}));
+const STUDENT_ID = 1;
+describe("useStudentDetailQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+  });
+  test("should fetch student details successfully", async () => {
+    const mockResponse = {
+      ...studentDetailMock,
+    } as StudentDetail;
+
+    vi.mocked(fetchStudent).mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() => useStudentDetailQuery(STUDENT_ID), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockResponse);
+  });
+
+  test("should handle error state", async () => {
+    const mockError = new Error("Failed to fetch student");
+
+    vi.mocked(fetchStudent).mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useStudentDetailQuery(STUDENT_ID), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(mockError);
+  });
+});

--- a/src/features/students/test/queries/useStudentsQuery.test.tsx
+++ b/src/features/students/test/queries/useStudentsQuery.test.tsx
@@ -1,14 +1,14 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
-import { useStudentsQuery } from '../../queries/useStudentsQuery';
-import { describe, expect, test, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useStudentsQuery } from "../../queries/useStudentsQuery";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
   mockMeta,
   studentsMock,
-} from '../../../../tests/fixtures/students/students';
-import { fetchStudents } from '../../api/studentsApi';
-import type z from 'zod';
-import type { fetchStudentsSuccessResponseSchema } from '../../types/students';
+} from "../../../../tests/fixtures/students/students";
+import { fetchStudents } from "../../api/studentsApi";
+import type z from "zod";
+import type { fetchStudentsSuccessResponseSchema } from "../../types/students";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -22,12 +22,16 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
-vi.mock('../../api/studentsApi', () => ({
+vi.mock("../../api/studentsApi", () => ({
   fetchStudents: vi.fn(),
 }));
 
-describe('useStudentsQuery', () => {
-  test('should fetch students successfully', async () => {
+describe("useStudentsQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+  });
+  test("should fetch students successfully", async () => {
     const mockFilters = {
       searchKeyword: undefined,
       school_stage: undefined,
@@ -53,7 +57,7 @@ describe('useStudentsQuery', () => {
     expect(result.current.data).toEqual(mockResponse);
   });
 
-  test('should handle error state', async () => {
+  test("should not fetch students when disabled", async () => {
     const mockFilters = {
       searchKeyword: undefined,
       school_stage: undefined,
@@ -61,7 +65,27 @@ describe('useStudentsQuery', () => {
       page: 1,
       perPage: 10,
     };
-    const mockError = new Error('Failed to fetch students');
+
+    const { result } = renderHook(
+      () => useStudentsQuery(mockFilters, { enabled: false }),
+      {
+        wrapper,
+      }
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(fetchStudents).not.toHaveBeenCalled();
+  });
+
+  test("should handle error state", async () => {
+    const mockFilters = {
+      searchKeyword: undefined,
+      school_stage: undefined,
+      grade: undefined,
+      page: 1,
+      perPage: 10,
+    };
+    const mockError = new Error("Failed to fetch students");
 
     vi.mocked(fetchStudents).mockRejectedValueOnce(mockError);
 

--- a/src/tests/fixtures/lessonNotes/lessonNotes.ts
+++ b/src/tests/fixtures/lessonNotes/lessonNotes.ts
@@ -1,0 +1,148 @@
+import type {
+  LessonNoteCreate,
+  LessonNoteCreateRequest,
+  LessonNoteEdit,
+  lessonNoteType,
+  LessonNoteUpdateRequest,
+} from "@/features/lessonNotes/types/lessonNote";
+import { addDays, format } from "date-fns";
+import { teacher1, teacher2, teacher3 } from "../teachers/teachers";
+import type { LessonNoteFormCreateValues } from "@/features/lessonNotes/types/lessonNoteForm";
+import type { ClassSubjectType } from "@/features/students/types/students";
+
+export const lessonNote1: lessonNoteType = {
+  id: 1,
+  title: "英語の宿題",
+  description: "次回の授業までに問題集の1章を解いてくること。",
+  note_type: "homework",
+  created_by_name: teacher1.name,
+  last_updated_by_name: teacher2.name,
+  expire_date: format(addDays(new Date(), 30), "yyyy-MM-dd"),
+  created_by: {
+    id: teacher1.id, // idは2
+    name: teacher1.name,
+  },
+  last_updated_by: {
+    id: teacher2.id, // idは3
+    name: teacher2.name,
+  },
+  student_class_subject: {
+    id: 1,
+    class_subject: {
+      id: 1,
+      name: "english",
+    },
+  },
+  created_at: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss'Z'"),
+  updated_at: format(addDays(new Date(), 1), "yyyy-MM-dd'T'HH:mm:ss'Z'"),
+};
+
+export const lessonNote2: lessonNoteType = {
+  id: 2,
+  title: "英語の授業",
+  description: "テストが近いので、テスト対策用の問題集を使用する。",
+  note_type: "lesson",
+  created_by_name: teacher2.name,
+  last_updated_by_name: null,
+  expire_date: format(new Date(), "yyyy-MM-dd"),
+  created_by: {
+    id: teacher2.id, // idは3
+    name: teacher2.name,
+  },
+  last_updated_by: null,
+  student_class_subject: {
+    id: 1,
+    class_subject: {
+      id: 1,
+      name: "english",
+    },
+  },
+  created_at: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss'Z'"),
+  updated_at: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss'Z'"),
+};
+
+export const lessonNote3: lessonNoteType = {
+  id: 3,
+  title: "数学の宿題",
+  description: "次回の授業までに問題集の2章を解いてくること。",
+  note_type: "homework",
+  created_by_name: teacher3.name,
+  last_updated_by_name: null,
+  expire_date: format(new Date(), "yyyy-MM-dd"),
+  created_by: {
+    id: teacher3.id, // idは4
+    name: teacher3.name,
+  },
+  last_updated_by: null,
+  student_class_subject: {
+    id: 2,
+    class_subject: {
+      id: 3,
+      name: "mathematics",
+    },
+  },
+  created_at: format(new Date(), "2024-01-01T10:00:00'Z'"),
+  updated_at: format(new Date(), "2024-01-01T10:00:00'Z'"),
+};
+// 英語でフィルタリングするようにするのでlesson3入れない
+export const lessonNotesMock: lessonNoteType[] = [lessonNote1, lessonNote2];
+
+export const LessonNotesMeta = {
+  total_pages: 1,
+  total_count: 2,
+  current_page: 1,
+  per_page: 10,
+};
+
+export const lessonNoteCreateFormMockValue: LessonNoteCreate = {
+  subject_id: 1,
+  title: lessonNote1.title,
+  description: lessonNote1.description,
+  note_type: lessonNote1.note_type,
+  expire_date: lessonNote1.expire_date,
+};
+
+export const createLessonNotePayload: LessonNoteCreateRequest = {
+  student_id: 1,
+  ...lessonNoteCreateFormMockValue,
+};
+
+export const createResponseLessonNoteMock: lessonNoteType = lessonNote1;
+
+export const editLessonNoteFormMockValue: LessonNoteEdit = {
+  id: lessonNote1.id,
+  subject_id: lessonNote1.student_class_subject.class_subject.id,
+  title: "更新後のタイトル",
+  description: "更新後の説明",
+  note_type: lessonNote1.note_type,
+  expire_date: lessonNote1.expire_date,
+};
+
+export const editLessonNotePayload: LessonNoteUpdateRequest = {
+  ...editLessonNoteFormMockValue,
+  student_id: 1,
+};
+
+export const editResponseLessonNoteMock: lessonNoteType = {
+  ...lessonNote1,
+  title: "更新後のタイトル",
+  description: "更新後の説明",
+};
+
+export const initialLessonFormCreateMockValue: LessonNoteFormCreateValues = {
+  subject_id: undefined,
+  title: "",
+  description: null,
+  note_type: undefined,
+  expire_date: undefined,
+};
+
+export const initialLessonFormEditMockValue: LessonNoteEdit = {
+  ...lessonNoteCreateFormMockValue,
+  id: lessonNote1.id,
+};
+
+export const mockSubjects: ClassSubjectType[] = [
+  { id: 1, name: "english" },
+  { id: 3, name: "mathematics" },
+];

--- a/src/tests/fixtures/students/students.ts
+++ b/src/tests/fixtures/students/students.ts
@@ -1,3 +1,4 @@
+import type { StudentDetail } from "@/features/studentDashboard/type/studentDashboard";
 import type { Draft } from "@/features/students/types/studentForm";
 import type {
   createStudentPayload,
@@ -225,4 +226,18 @@ export const initialMockValue: Draft = {
   subject_ids: [],
   available_day_ids: [],
   assignments: [],
+};
+
+export const studentDetailMock: StudentDetail = {
+  id: mockStudent1.id,
+  name: mockStudent1.name,
+  status: mockStudent1.status,
+  school_stage: mockStudent1.school_stage,
+  grade: mockStudent1.grade,
+  desired_school: mockStudent1.desired_school,
+  joined_on: mockStudent1.joined_on,
+  class_subjects: [
+    mockStudent1.class_subjects[0],
+    mockStudent1.class_subjects[2],
+  ], // 英語、数学
 };

--- a/src/tests/integration/students/studentUpdate.test.tsx
+++ b/src/tests/integration/students/studentUpdate.test.tsx
@@ -135,7 +135,7 @@ describe("Student Update Page", () => {
     expect(
       await screen.findByText("生徒名は50文字以内で入力してください")
     ).toBeInTheDocument();
-  });
+  }, 20000);
   test("should not display a form for updating a student if the role is teacher", async () => {
     updateRender("teacher");
 


### PR DESCRIPTION
## ISSUE

close #173 

## 実装概要

- Lesson Note（引継ぎ事項）機能まわりのユニットテスト・APIテスト・Mutationテスト・Hookテストを一括追加。フォーム分岐（作成/編集）仕様確定、Subject 選択の挙動整理、Drawer / Dialog / Header / HoverCard など表示系の型・テスト強化。
- 既存コンポーネントの一部 props 型を外部利用向けに export。student / lesson note 関連の Query テストも追加し、失敗時ハンドリングと enabled 制御も検証。
- 副次的に: SubjectSelect の制御方法変更（内部 state 化）、編集フォームで科目固定表示（SubjectField）、各 Form Part の型公開、fixture 拡張。



## 影響範囲

<!-- この変更が影響する画面・機能・ファイルなどを記載してください（例：todo一覧画面、Userモデルなど） -->
- LessonNoteForm（科目選択→分岐 / SubjectField 追加）
- SubjectSelect（controlled → internal state）
- NoteTypeSelect / ExpireDatePicker / Title / Description 各フィールド（型 export）
- Create / Edit LessonNote Dialog（テスト & フォーム連携）
- LessonNoteDrawer（ラベル/表示整理 & 型 export）
- lessonNotes API / Mutation / Query テスト追加
- studentDashboard SiteHeader / HoverCard（型 export & テスト）
- students/useStudentsQuery テスト拡張（enabled:false 分岐）
- fixtures 追加（lessonNotes / studentDetailMock）

## レビューポイント

<!-- レビュアーに特に見てほしい点があればチェックを入れてください -->

- SubjectSelect の内部 state 化で逆に親 state 同期漏れが生じるケースがないか
- 編集モードで科目変更不可とする仕様妥当性
- Mutation onSuccess のキャッシュ更新キー（lists/detail）に漏れがないか
- Zod スキーマに対する API テスト（invalid レスポンス時の throw）十分か
- Drawer / Dialog のアクセシビリティ（role, ラベル）維持
- フォームハンドラ（lessonNoteFormHandlers）テストで create/edit 分岐網羅されているか

## デプロイ／運用

<!-- 該当する項目にチェックを入れて、必要に応じて補足してください -->

- **マイグレーション**： 無
- **環境変数の追加**： 無
- **破壊的変更の有無**： 無

## チェックリスト（作成者用）

<!-- PR作成前に確認した内容にチェックを入れてください -->

- [ ] 自身で動作確認・コードレビューを完了した
- [ ] 不要なコメント・デバッグコードを削除した
- [ ] コミットメッセージがわかりやすく記述されている
- [ ] 関連 Issue がリンクされている（あれば）

## チェックリスト（レビュアー用）

- [ ] 命名が一貫性をもち、一貫性があるか
- [ ] 処理が重複していないか
- [ ] コントローラーが肥大化していないか
- [ ] テストがあり、目的をカバーしているか
- [ ] UX や画面に不自然さがないか
